### PR TITLE
feat: add app bootstrap with router guards and navigate helper

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,0 +1,36 @@
+import { ROUTES } from '../types';
+import { createRouter } from './router';
+import { createLayout } from './layout';
+import { auth } from './services/auth';
+import { setNavigate } from './navigation';
+
+import { createLandingView } from '../pages/landing';
+import { createLoginView } from '../pages/login';
+import { createDashboardView } from '../pages/dashboard';
+
+export function initApp(mount: HTMLElement): void {
+  const layout = createLayout();
+  mount.replaceChildren(layout.root);
+
+  const router = createRouter({
+    mount: layout.outlet,
+    fallback: ROUTES.Landing,
+    isAuthed: auth.isAuthed,
+    routes: {
+      [ROUTES.Landing]: { createView: createLandingView },
+      [ROUTES.Login]: {
+        createView: createLoginView,
+        guard: 'guest',
+        redirectTo: ROUTES.Dashboard,
+      },
+      [ROUTES.Dashboard]: {
+        createView: createDashboardView,
+        guard: 'authed',
+        redirectTo: ROUTES.Login,
+      },
+    },
+  });
+
+  setNavigate(router.go);
+  router.start();
+}

--- a/src/app/layout.ts
+++ b/src/app/layout.ts
@@ -1,0 +1,53 @@
+import { ROUTES } from '../types';
+
+export type AppLayout = {
+  root: HTMLElement;
+  outlet: HTMLElement;
+};
+
+export function createLayout(): AppLayout {
+  const root = document.createElement('div');
+  root.className = 'app';
+  root.style.display = 'flex';
+  root.style.flexDirection = 'column';
+  root.style.minHeight = '100vh';
+
+  // HEADER
+  const header = document.createElement('header');
+  header.className = 'app-header';
+  header.style.padding = '16px 24px';
+  header.style.borderBottom = '1px solid #ddd';
+
+  const nav = document.createElement('nav');
+  nav.className = 'nav';
+  nav.style.display = 'flex';
+  nav.style.gap = '16px';
+
+  const linkLanding = document.createElement('a');
+  linkLanding.textContent = 'Landing';
+  linkLanding.href = ROUTES.Landing;
+  linkLanding.setAttribute('data-link', '');
+
+  const linkLogin = document.createElement('a');
+  linkLogin.textContent = 'Login';
+  linkLogin.href = ROUTES.Login;
+  linkLogin.setAttribute('data-link', '');
+
+  const linkDashboard = document.createElement('a');
+  linkDashboard.textContent = 'Dashboard';
+  linkDashboard.href = ROUTES.Dashboard;
+  linkDashboard.setAttribute('data-link', '');
+
+  nav.append(linkLanding, linkLogin, linkDashboard);
+  header.append(nav);
+
+  // MAIN (outlet для страниц)
+  const outlet = document.createElement('main');
+  outlet.className = 'app-main';
+  outlet.style.flex = '1';
+  outlet.style.padding = '24px';
+
+  root.append(header, outlet);
+
+  return { root, outlet };
+}

--- a/src/app/navigation.ts
+++ b/src/app/navigation.ts
@@ -1,0 +1,14 @@
+import type { RoutePath } from '../types';
+
+let navigateImpl: ((to: RoutePath, replace?: boolean) => void) | null = null;
+
+export function setNavigate(
+  fn: (to: RoutePath, replace?: boolean) => void
+): void {
+  navigateImpl = fn;
+}
+
+export function navigate(to: RoutePath, replace = false): void {
+  if (!navigateImpl) throw new Error('navigate() used before setNavigate()');
+  navigateImpl(to, replace);
+}

--- a/src/app/router.ts
+++ b/src/app/router.ts
@@ -1,0 +1,80 @@
+import type { RoutePath } from '../types';
+
+type RouteConfig = {
+  createView: () => HTMLElement;
+  guard?: 'authed' | 'guest'; // authed: только для залогиненных, guest: только для гостей
+  redirectTo?: RoutePath; // куда редиректить если guard не прошёл
+};
+
+type RoutesMap = Partial<Record<RoutePath, RouteConfig>>;
+
+// Опции роута
+type CreateRouterOptions = {
+  mount: HTMLElement; // куда "вставлять" текущую страницу
+  routes: RoutesMap; // routes: список маршрутов
+  fallback: RoutePath; // что показывать, если путь неизвестный
+  isAuthed: () => boolean; // функция проверки авторизации (роутер не знает, где хранится токен/флаг)
+};
+
+export type Router = {
+  start: () => void; // запуск слушателей + первый рендер
+  go: (to: RoutePath, replace?: boolean) => void;
+};
+
+export const createRouter = (options: CreateRouterOptions): Router => {
+  const { mount, routes, fallback, isAuthed } = options;
+
+  // Получить конфиг маршрута по path:
+  const resolve = (path: RoutePath): RouteConfig => {
+    return (
+      routes[path] ??
+      routes[fallback] ?? { createView: () => document.createElement('div') }
+    );
+  };
+
+  // Рендер текущего URL
+  const render = (): void => {
+    const path = (window.location.pathname || fallback) as RoutePath; // текущий путь
+    const route = resolve(path); // берём конфиг для этого пути (или fallback)
+
+    if (route.guard === 'authed' && !isAuthed()) {
+      go(route.redirectTo ?? fallback, true);
+      return;
+    }
+
+    if (route.guard === 'guest' && isAuthed()) {
+      go(route.redirectTo ?? fallback, true);
+      return;
+    }
+
+    // "Отрисовать" текущую страницу:
+    mount.replaceChildren(route.createView());
+    window.scrollTo(0, 0); // на всякий случай скроллим вверх при смене страницы
+  };
+
+  // Навигация на другой путь
+  const go = (to: RoutePath, replace = false): void => {
+    if (replace) history.replaceState(null, '', to);
+    else history.pushState(null, '', to);
+    render();
+  };
+
+  const start = (): void => {
+    document.addEventListener('click', (event) => {
+      const target = event.target instanceof Element ? event.target : null; // по типам TS это может быть не Element (напр, Text узел) -> приводим к Element | null.
+      const link = target?.closest<HTMLAnchorElement>('a[data-link]') ?? null; // нашли link через closest
+      if (!link) return;
+
+      const href = link.getAttribute('href') as RoutePath | null;
+      if (!href) return;
+
+      event.preventDefault();
+      go(href);
+    });
+
+    window.addEventListener('popstate', render); // пользователь нажал Back / Forward
+    render();
+  };
+
+  return { start, go };
+};

--- a/src/app/services/auth.ts
+++ b/src/app/services/auth.ts
@@ -1,0 +1,20 @@
+import type { StorageService } from './storage';
+import { createStorageService } from './storage';
+
+const AUTH_KEY = 'auth:isAuthenticated';
+
+export type AuthService = {
+  isAuthed: () => boolean;
+  login: () => void;
+  logout: () => void;
+};
+
+export const createAuthService = (storage: StorageService): AuthService => ({
+  isAuthed: () => storage.get(AUTH_KEY) === '1',
+  login: () => storage.set(AUTH_KEY, '1'),
+  logout: () => storage.remove(AUTH_KEY),
+});
+
+// singleton, чтобы можно было пользоваться из страниц и из App.ts
+const storage = createStorageService();
+export const auth = createAuthService(storage);

--- a/src/app/services/storage.ts
+++ b/src/app/services/storage.ts
@@ -1,0 +1,11 @@
+export type StorageService = {
+  get: (key: string) => string | null;
+  set: (key: string, value: string) => void;
+  remove: (key: string) => void;
+};
+
+export const createStorageService = (): StorageService => ({
+  get: (key) => localStorage.getItem(key),
+  set: (key, value) => localStorage.setItem(key, value),
+  remove: (key) => localStorage.removeItem(key),
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,14 @@
 import './styles/main.scss';
+import { initApp } from './app/app';
+
+function getOrCreateMount(): HTMLElement {
+  const existing = document.getElementById('app');
+  if (existing) return existing;
+
+  const root = document.createElement('div');
+  root.id = 'app';
+  document.body.append(root);
+  return root;
+}
+
+initApp(getOrCreateMount());

--- a/src/pages/dashboard.ts
+++ b/src/pages/dashboard.ts
@@ -1,0 +1,26 @@
+import { ROUTES } from '../types';
+import { auth } from '../app/services/auth';
+import { navigate } from '../app/navigation';
+
+export const createDashboardView = (): HTMLElement => {
+  const section = document.createElement('section');
+  section.style.display = 'flex';
+  section.style.flexDirection = 'column';
+  section.style.gap = '16px';
+
+  const title = document.createElement('h1');
+  title.textContent =
+    'Dashboard. Тут у нас будет профиль пользователя :) А еще много классных виджетов!';
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Logout';
+
+  btn.addEventListener('click', () => {
+    auth.logout();
+    navigate(ROUTES.Landing, true);
+  });
+
+  section.append(title, btn);
+  return section;
+};

--- a/src/pages/landing.ts
+++ b/src/pages/landing.ts
@@ -1,0 +1,30 @@
+import { ROUTES } from '../types';
+import { navigate } from '../app/navigation';
+
+export const createLandingView = (): HTMLElement => {
+  const section = document.createElement('section');
+  section.style.display = 'flex';
+  section.style.flexDirection = 'column';
+  section.style.gap = '16px';
+
+  const title = document.createElement('h1');
+  title.textContent =
+    'Landing. Привет! Тут мы сделаем классное описание нашего тренажера :)';
+
+  const buttons = document.createElement('div');
+  buttons.style.display = 'flex';
+  buttons.style.gap = '12px';
+
+  const toLogin = document.createElement('button');
+  toLogin.textContent = 'Login';
+  toLogin.onclick = () => navigate(ROUTES.Login);
+
+  const toDash = document.createElement('button');
+  toDash.textContent = 'Main';
+  toDash.onclick = () => navigate(ROUTES.Dashboard);
+
+  buttons.append(toLogin, toDash);
+  section.append(title, buttons);
+
+  return section;
+};

--- a/src/pages/login.ts
+++ b/src/pages/login.ts
@@ -1,0 +1,25 @@
+import { ROUTES } from '../types';
+import { auth } from '../app/services/auth';
+import { navigate } from '../app/navigation';
+
+export const createLoginView = (): HTMLElement => {
+  const section = document.createElement('section');
+  section.style.display = 'flex';
+  section.style.flexDirection = 'column';
+  section.style.gap = '16px';
+
+  const title = document.createElement('h1');
+  title.textContent = 'Login';
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Mock login';
+
+  btn.addEventListener('click', () => {
+    auth.login();
+    navigate(ROUTES.Dashboard, true);
+  });
+
+  section.append(title, btn);
+  return section;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+export const ROUTES = {
+  Landing: '/landing',
+  Login: '/login',
+  Dashboard: '/dashboard',
+} as const;
+
+export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
+
+// export type RouteKey = 'landing' | 'login' | 'dashboard';
+
+export type AuthState = {
+  isAuthenticated: boolean;
+  login?: string;
+  // password?: string;
+};


### PR DESCRIPTION
## Что сделано

- Добавлен App Core (инициализация приложения):
  - `initApp()` собирает layout, router и auth-сервис
  - в `main.ts` — только создание mount и запуск `initApp`

- Добавлен layout приложения:
  - общий каркас (header + outlet)
  - роутер рендерит страницы в `outlet`

- Реализован простой SPA Router:
  - client-side навигация через History API
  - поддержка back/forward (`popstate`)
  - guards для маршрутов:
    - `authed` — доступ только для авторизованных
    - `guest` — доступ только для неавторизованных
  - редиректы выполняются через `replaceState` (без засорения истории)

- Добавлена навигация для UI через `navigate()`:
  - `setNavigate(router.go)` подключает роутер

- Добавлен mock auth:
  - `AuthService` + `StorageService`
  - единый ключ `auth:isAuthenticated`
  - `login()` / `logout()` меняют состояние в localStorage

## Страницы

- Landing: кнопки перехода на Login/Dashboard через `navigate()`
- Login: mock login → `auth.login()` + переход на Dashboard
- Dashboard: logout → `auth.logout()` + переход на Landing

## Как проверить

1. Открыть `/login` и нажать **Mock login** → переход на `/dashboard`
2. Проверить guard: при `auth:isAuthenticated=1` маршрут `/login` редиректит на `/dashboard`
3. Нажать **Logout** → переход на `/landing`
4. Проверить guard: без авторизации `/dashboard` редиректит на `/login`

<img width="1470" height="956" alt="Screenshot 2026-02-24 at 20 39 44" src="https://github.com/user-attachments/assets/9abdb3f5-7ae7-46a4-b3ac-67e217d47584" />
