### PR TITLE
Feature/active game warning modal

### DIFF
--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -1,17 +1,16 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { fireEvent, screen, waitFor } from '@testing-library/dom';
-import { within } from '@testing-library/dom';
+import { fireEvent, screen, waitFor, within } from '@testing-library/dom';
 
 const mocks = vi.hoisted(() => ({
   getTopics: vi.fn(),
   navigate: vi.fn(),
   startNewGame: vi.fn(),
   saveTopics: vi.fn(),
+  restoreGameState: vi.fn(),
   getState: vi.fn(),
   fetchCompletedTopicIds: vi.fn(),
   showModal: vi.fn(),
-  getActiveGame: vi.fn(),
-  hasRequiredResumeData: vi.fn(),
+  getResumeCandidate: vi.fn(),
 }));
 
 vi.mock('../../services/api/get-topics', () => ({
@@ -33,18 +32,15 @@ vi.mock('../../app/state/store', () => ({
 vi.mock('../../app/state/actions', () => ({
   startNewGame: mocks.startNewGame,
   saveTopics: mocks.saveTopics,
+  restoreGameState: mocks.restoreGameState,
 }));
 
 vi.mock('../../components/ui/modal/modal', () => ({
   showModal: mocks.showModal,
 }));
 
-vi.mock('../../services/storageService', () => ({
-  getActiveGame: mocks.getActiveGame,
-}));
-
 vi.mock('../../services/resumeActiveGame', () => ({
-  hasRequiredResumeData: mocks.hasRequiredResumeData,
+  getResumeCandidate: mocks.getResumeCandidate,
 }));
 
 import { createLibraryView } from './library';
@@ -66,12 +62,12 @@ describe('createLibraryView', () => {
         wrongAnswers: [],
         questions: [],
       },
+      topics: [],
       isLoading: false,
     });
 
     mocks.fetchCompletedTopicIds.mockResolvedValue([]);
-    mocks.getActiveGame.mockReturnValue(null);
-    mocks.hasRequiredResumeData.mockReturnValue(false);
+    mocks.getResumeCandidate.mockResolvedValue(null);
     mocks.showModal.mockResolvedValue({ confirmed: true });
   });
 
@@ -130,6 +126,7 @@ describe('createLibraryView', () => {
   test('starts new game and navigates to practice after clicking Start', async () => {
     mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
     mocks.startNewGame.mockResolvedValue(undefined);
+    mocks.getResumeCandidate.mockResolvedValue(null);
 
     const view = createLibraryView();
     document.body.append(view);
@@ -205,7 +202,7 @@ describe('createLibraryView', () => {
   test('starts new game without modal when there is no active game', async () => {
     mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
     mocks.startNewGame.mockResolvedValue(undefined);
-    mocks.getActiveGame.mockReturnValue(null);
+    mocks.getResumeCandidate.mockResolvedValue(null);
 
     const view = createLibraryView();
     document.body.append(view);
@@ -228,10 +225,14 @@ describe('createLibraryView', () => {
 
   test('navigates to practice without starting a new game for the same active game', async () => {
     mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
-    mocks.getActiveGame.mockReturnValue({
+    mocks.getResumeCandidate.mockResolvedValue({
       topicId: 1,
       difficulty: 'easy',
       round: 2,
+      score: 0,
+      usedHints: [],
+      wrongAnswers: [],
+      questions: [{ id: 1 }],
     });
 
     const view = createLibraryView();
@@ -244,6 +245,12 @@ describe('createLibraryView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
     await waitFor(() => {
+      expect(mocks.restoreGameState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topicId: 1,
+          difficulty: 'easy',
+        })
+      );
       expect(mocks.showModal).not.toHaveBeenCalled();
       expect(mocks.startNewGame).not.toHaveBeenCalled();
       expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
@@ -269,13 +276,16 @@ describe('createLibraryView', () => {
       isLoading: false,
     });
 
-    mocks.getActiveGame.mockReturnValue({
+    mocks.getResumeCandidate.mockResolvedValue({
       topicId: 1,
       difficulty: 'easy',
       round: 2,
+      score: 0,
+      usedHints: [],
+      wrongAnswers: [],
+      questions: [{ id: 1 }],
     });
 
-    mocks.hasRequiredResumeData.mockReturnValue(true);
     mocks.showModal.mockResolvedValue({ confirmed: true });
 
     const view = createLibraryView();
@@ -331,13 +341,16 @@ describe('createLibraryView', () => {
       isLoading: false,
     });
 
-    mocks.getActiveGame.mockReturnValue({
+    mocks.getResumeCandidate.mockResolvedValue({
       topicId: 1,
       difficulty: 'easy',
       round: 2,
+      score: 0,
+      usedHints: [],
+      wrongAnswers: [],
+      questions: [{ id: 1 }],
     });
 
-    mocks.hasRequiredResumeData.mockReturnValue(true);
     mocks.showModal.mockResolvedValue({ confirmed: false });
 
     const view = createLibraryView();
@@ -368,7 +381,7 @@ describe('createLibraryView', () => {
   test('shows error message and re-enables button when startNewGame fails', async () => {
     mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
     mocks.startNewGame.mockRejectedValue(new Error('Start failed'));
-    mocks.getActiveGame.mockReturnValue(null);
+    mocks.getResumeCandidate.mockResolvedValue(null);
 
     const view = createLibraryView();
     document.body.append(view);

--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -223,8 +223,24 @@ describe('createLibraryView', () => {
     });
   });
 
-  test('navigates to practice without starting a new game for the same active game', async () => {
+  test('shows confirmation modal and restores same active game after confirmation', async () => {
     mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+
+    mocks.getState.mockReturnValue({
+      user: null,
+      game: {
+        topicId: 0,
+        difficulty: '',
+        round: 0,
+        score: 0,
+        usedHints: [],
+        wrongAnswers: [],
+        questions: [],
+      },
+      topics: [{ id: 1, name: 'HTML' }],
+      isLoading: false,
+    });
+
     mocks.getResumeCandidate.mockResolvedValue({
       topicId: 1,
       difficulty: 'easy',
@@ -234,6 +250,8 @@ describe('createLibraryView', () => {
       wrongAnswers: [],
       questions: [{ id: 1 }],
     });
+
+    mocks.showModal.mockResolvedValue({ confirmed: true });
 
     const view = createLibraryView();
     document.body.append(view);
@@ -245,13 +263,19 @@ describe('createLibraryView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
     await waitFor(() => {
+      expect(mocks.showModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Continue previous game?',
+          messageHtml: expect.stringContaining('HTML'),
+        })
+      );
+
       expect(mocks.restoreGameState).toHaveBeenCalledWith(
         expect.objectContaining({
           topicId: 1,
           difficulty: 'easy',
         })
       );
-      expect(mocks.showModal).not.toHaveBeenCalled();
       expect(mocks.startNewGame).not.toHaveBeenCalled();
       expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
     });

--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../components/ui/modal/modal', () => ({
   showModal: mocks.showModal,
 }));
 
-vi.mock('../../services/resumeActiveGame', () => ({
+vi.mock('../../services/resume-active-game', () => ({
   getResumeCandidate: mocks.getResumeCandidate,
 }));
 

--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
   saveTopics: vi.fn(),
   getState: vi.fn(),
   fetchCompletedTopicIds: vi.fn(),
+  showModal: vi.fn(),
+  getActiveGame: vi.fn(),
+  hasRequiredResumeData: vi.fn(),
 }));
 
 vi.mock('../../services/api/get-topics', () => ({
@@ -30,6 +33,18 @@ vi.mock('../../app/state/store', () => ({
 vi.mock('../../app/state/actions', () => ({
   startNewGame: mocks.startNewGame,
   saveTopics: mocks.saveTopics,
+}));
+
+vi.mock('../../components/ui/modal/modal', () => ({
+  showModal: mocks.showModal,
+}));
+
+vi.mock('../../services/storageService', () => ({
+  getActiveGame: mocks.getActiveGame,
+}));
+
+vi.mock('../../services/resumeActiveGame', () => ({
+  hasRequiredResumeData: mocks.hasRequiredResumeData,
 }));
 
 import { createLibraryView } from './library';
@@ -55,6 +70,9 @@ describe('createLibraryView', () => {
     });
 
     mocks.fetchCompletedTopicIds.mockResolvedValue([]);
+    mocks.getActiveGame.mockReturnValue(null);
+    mocks.hasRequiredResumeData.mockReturnValue(false);
+    mocks.showModal.mockResolvedValue({ confirmed: true });
   });
 
   test('renders title and subtitle', () => {
@@ -131,56 +149,240 @@ describe('createLibraryView', () => {
       expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
     });
   });
-});
 
-test('marks completed topic and disables Start button', async () => {
-  mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
-  mocks.fetchCompletedTopicIds.mockResolvedValue([1]);
+  test('marks completed topic and disables Start button', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+    mocks.fetchCompletedTopicIds.mockResolvedValue([1]);
 
-  const view = createLibraryView();
-  document.body.append(view);
+    const view = createLibraryView();
+    document.body.append(view);
 
-  await waitFor(() => {
-    const card = within(view).getByText('HTML').closest('.library-card');
-    expect(card).toHaveClass('is-completed');
+    await waitFor(() => {
+      const card = within(view).getByText('HTML').closest('.library-card');
+      expect(card).toHaveClass('is-completed');
 
-    const startBtn = within(card as HTMLElement).getByRole('button', {
-      name: /start/i,
+      const startBtn = within(card as HTMLElement).getByRole('button', {
+        name: /start/i,
+      });
+      expect(startBtn).toBeDisabled();
     });
-    expect(startBtn).toBeDisabled();
+
+    expect(view.querySelector('.topic-icon')).not.toBeNull();
   });
 
-  expect(view.querySelector('.topic-icon')).not.toBeNull();
-});
+  test('loads completed topics for selected difficulty', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+    mocks.fetchCompletedTopicIds.mockResolvedValue([]);
 
-test('loads completed topics for selected difficulty', async () => {
-  mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
-  mocks.fetchCompletedTopicIds.mockResolvedValue([]);
+    const view = createLibraryView();
+    document.body.append(view);
 
-  const view = createLibraryView();
-  document.body.append(view);
+    await waitFor(() => {
+      expect(mocks.fetchCompletedTopicIds).toHaveBeenCalledWith('easy');
+    });
 
-  await waitFor(() => {
-    expect(mocks.fetchCompletedTopicIds).toHaveBeenCalledWith('easy');
+    mocks.fetchCompletedTopicIds.mockClear();
+
+    const mediumBtn = within(view).getByRole('button', { name: 'Medium' });
+    fireEvent.click(mediumBtn);
+
+    await waitFor(() => {
+      expect(mocks.fetchCompletedTopicIds).toHaveBeenCalledWith('medium');
+    });
   });
 
-  mocks.fetchCompletedTopicIds.mockClear();
+  test('shows error message when topics loading fails', async () => {
+    mocks.getTopics.mockRejectedValue(new Error('Failed to load topics.'));
 
-  const mediumBtn = within(view).getByRole('button', { name: 'Medium' });
-  fireEvent.click(mediumBtn);
+    const view = createLibraryView();
+    document.body.append(view);
 
-  await waitFor(() => {
-    expect(mocks.fetchCompletedTopicIds).toHaveBeenCalledWith('medium');
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load topics.')).toBeInTheDocument();
+    });
   });
-});
 
-test('shows error message when topics loading fails', async () => {
-  mocks.getTopics.mockRejectedValue(new Error('Failed to load topics.'));
+  test('starts new game without modal when there is no active game', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+    mocks.startNewGame.mockResolvedValue(undefined);
+    mocks.getActiveGame.mockReturnValue(null);
 
-  const view = createLibraryView();
-  document.body.append(view);
+    const view = createLibraryView();
+    document.body.append(view);
 
-  await waitFor(() => {
-    expect(screen.getByText('Failed to load topics.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+    await waitFor(() => {
+      expect(mocks.showModal).not.toHaveBeenCalled();
+      expect(mocks.startNewGame).toHaveBeenCalledWith({
+        topicId: 1,
+        difficulty: 'easy',
+      });
+      expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
+    });
+  });
+
+  test('navigates to practice without starting a new game for the same active game', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+    mocks.getActiveGame.mockReturnValue({
+      topicId: 1,
+      difficulty: 'easy',
+      round: 2,
+    });
+
+    const view = createLibraryView();
+    document.body.append(view);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+    await waitFor(() => {
+      expect(mocks.showModal).not.toHaveBeenCalled();
+      expect(mocks.startNewGame).not.toHaveBeenCalled();
+      expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
+    });
+  });
+
+  test('shows modal and starts a new game after confirmation when another active game exists', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+    mocks.startNewGame.mockResolvedValue(undefined);
+
+    mocks.getState.mockReturnValue({
+      user: null,
+      game: {
+        topicId: 0,
+        difficulty: '',
+        round: 0,
+        score: 0,
+        usedHints: [],
+        wrongAnswers: [],
+        questions: [],
+      },
+      topics: [{ id: 1, name: 'HTML' }],
+      isLoading: false,
+    });
+
+    mocks.getActiveGame.mockReturnValue({
+      topicId: 1,
+      difficulty: 'easy',
+      round: 2,
+    });
+
+    mocks.hasRequiredResumeData.mockReturnValue(true);
+    mocks.showModal.mockResolvedValue({ confirmed: true });
+
+    const view = createLibraryView();
+    document.body.append(view);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Medium' })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Medium' }));
+
+    await waitFor(() => {
+      expect(mocks.fetchCompletedTopicIds).toHaveBeenCalledWith('medium');
+    });
+
+    const startBtn = await screen.findByRole('button', { name: 'Start' });
+    fireEvent.click(startBtn);
+
+    await waitFor(() => {
+      expect(mocks.showModal).toHaveBeenCalled();
+      expect(mocks.startNewGame).toHaveBeenCalledWith({
+        topicId: 1,
+        difficulty: 'medium',
+      });
+      expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
+    });
+
+    expect(mocks.showModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Start new game?',
+        messageHtml: expect.stringContaining('HTML'),
+      })
+    );
+  });
+
+  test('does not start a new game when modal is cancelled', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+
+    mocks.getState.mockReturnValue({
+      user: null,
+      game: {
+        topicId: 0,
+        difficulty: '',
+        round: 0,
+        score: 0,
+        usedHints: [],
+        wrongAnswers: [],
+        questions: [],
+      },
+      topics: [{ id: 1, name: 'HTML' }],
+      isLoading: false,
+    });
+
+    mocks.getActiveGame.mockReturnValue({
+      topicId: 1,
+      difficulty: 'easy',
+      round: 2,
+    });
+
+    mocks.hasRequiredResumeData.mockReturnValue(true);
+    mocks.showModal.mockResolvedValue({ confirmed: false });
+
+    const view = createLibraryView();
+    document.body.append(view);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Medium' })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Medium' }));
+
+    await waitFor(() => {
+      expect(mocks.fetchCompletedTopicIds).toHaveBeenCalledWith('medium');
+    });
+
+    const startBtn = await screen.findByRole('button', { name: 'Start' });
+    fireEvent.click(startBtn);
+
+    await waitFor(() => {
+      expect(mocks.showModal).toHaveBeenCalled();
+      expect(mocks.startNewGame).not.toHaveBeenCalled();
+      expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  test('shows error message and re-enables button when startNewGame fails', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+    mocks.startNewGame.mockRejectedValue(new Error('Start failed'));
+    mocks.getActiveGame.mockReturnValue(null);
+
+    const view = createLibraryView();
+    document.body.append(view);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
+    });
+
+    const startBtn = screen.getByRole('button', { name: 'Start' });
+    fireEvent.click(startBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Start failed')).toBeInTheDocument();
+      expect(startBtn).not.toBeDisabled();
+    });
   });
 });

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -57,6 +57,25 @@ async function confirmReplaceActiveGame(
   return result.confirmed;
 }
 
+async function confirmContinueSameGame(
+  difficulty: Difficulty | null | undefined,
+  topicTitle: string
+): Promise<boolean> {
+  const result = await showModal({
+    title: 'Continue previous game?',
+    messageHtml: `
+      <p>You already have an unfinished game:</p>
+      <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
+      <p>Do you want to continue your previous progress?</p>
+`,
+    showConfirm: true,
+    confirmText: 'Continue game',
+    cancelText: 'Cancel',
+  });
+
+  return result.confirmed;
+}
+
 function createTopicCard(
   topic: Topic,
   isCompleted: boolean,
@@ -166,6 +185,16 @@ export const createLibraryView = (): HTMLElement => {
       const activeGame = await getResumeCandidate();
 
       if (activeGame && isSameActiveGame(activeGame, topicId, difficulty)) {
+        const activeTopicTitle = getTopicTitleById(activeGame.topicId);
+        const shouldContinue = await confirmContinueSameGame(
+          activeGame.difficulty,
+          activeTopicTitle
+        );
+
+        if (!shouldContinue) {
+          return;
+        }
+
         restoreGameState(activeGame);
         shouldEnableButton = false;
         navigate(ROUTES.Practice, true);

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -1,29 +1,33 @@
 import './library.scss';
-import { ROUTES, type Difficulty, type Topic } from '../../types';
+import {
+  ROUTES,
+  type AppState,
+  type Difficulty,
+  type Topic,
+} from '../../types';
 import { navigate } from '../../app/navigation';
 import { getTopics } from '../../services/api/get-topics';
 import { createEl, createButton } from '../../shared/dom';
-import { saveTopics, startNewGame } from '../../app/state/actions';
+import {
+  restoreGameState,
+  saveTopics,
+  startNewGame,
+} from '../../app/state/actions';
 import { createLoadingView } from '../../components/ui/loading/loading';
 import { createErrorMessage } from '../../components/ui/error-message/error-message';
 import { fetchCompletedTopicIds } from '../../services/api/fetch-completed-topic-ids';
 import { getState } from '../../app/state/store';
 import { showModal } from '../../components/ui/modal/modal';
-import { hasRequiredResumeData } from '../../services/resumeActiveGame';
-import { getActiveGame } from '../../services/storageService';
+import { getResumeCandidate } from '../../services/resumeActiveGame';
+
+type GameState = AppState['game'];
 
 function isSameActiveGame(
-  activeGame: ReturnType<typeof getActiveGame>,
+  activeGame: GameState,
   topicId: number,
   difficulty: Difficulty
 ): boolean {
-  if (!activeGame) return false;
-
-  return (
-    activeGame.topicId === topicId &&
-    activeGame.difficulty === difficulty &&
-    activeGame.round > 0
-  );
+  return activeGame.topicId === topicId && activeGame.difficulty === difficulty;
 }
 
 function getTopicTitleById(topicId: number): string {
@@ -41,10 +45,10 @@ async function confirmReplaceActiveGame(
   const result = await showModal({
     title: 'Start new game?',
     messageHtml: `
-     <p>You already have an unfinished game:</p>
+      <p>You already have an unfinished game:</p>
       <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
       <p>Starting a new game will replace your current progress.</p>
-    `,
+`,
     showConfirm: true,
     confirmText: 'Start new game',
     cancelText: 'Cancel',
@@ -84,7 +88,6 @@ function createTopicCard(
     topicIcon.src = '/img/tick-mark.png';
     topicIcon.alt = '';
     topicIcon.setAttribute('aria-hidden', 'true');
-
     actions.append(topicIcon);
   }
 
@@ -110,12 +113,12 @@ export const createLibraryView = (): HTMLElement => {
   let difficulty: Difficulty = getState().game.difficulty || 'easy';
 
   const difficultyRow = createEl('div', { className: 'library-difficulty' });
+
   const difficultyLabel = createEl('span', {
     text: 'Difficulty:',
     className: 'library-difficulty-label',
   });
 
-  // Меняет сложность и обновляет список тем.
   const handleDifficultyChange = (key: Difficulty) => {
     if (difficulty === key) return;
     difficulty = key;
@@ -143,7 +146,6 @@ export const createLibraryView = (): HTMLElement => {
   const status = createEl('div', { className: 'library-status' });
   const list = createEl('div', { className: 'library-list' });
 
-  // Подсвечивает активную кнопку сложности.
   const setActiveDifficultyUI = () => {
     (Object.keys(diffBtns) as Difficulty[]).forEach((key) => {
       diffBtns[key].classList.toggle('is-active', key === difficulty);
@@ -154,21 +156,21 @@ export const createLibraryView = (): HTMLElement => {
     topicId: number,
     startBtn: HTMLButtonElement
   ): Promise<void> => {
-    const activeGame = getActiveGame();
-
     status.textContent = '';
     status.classList.remove('is-error');
     startBtn.disabled = true;
 
     try {
-      if (isSameActiveGame(activeGame, topicId, difficulty)) {
+      const activeGame = await getResumeCandidate();
+
+      if (activeGame && isSameActiveGame(activeGame, topicId, difficulty)) {
+        restoreGameState(activeGame);
         navigate(ROUTES.Practice, true);
         return;
       }
 
-      if (activeGame && hasRequiredResumeData(activeGame)) {
+      if (activeGame) {
         const activeTopicTitle = getTopicTitleById(activeGame.topicId);
-
         const shouldReplace = await confirmReplaceActiveGame(
           activeGame.difficulty,
           activeTopicTitle
@@ -197,7 +199,6 @@ export const createLibraryView = (): HTMLElement => {
     }
   };
 
-  // Загружает и обновляет список тем.
   const updateTopicsList = async (): Promise<void> => {
     setActiveDifficultyUI();
     list.replaceChildren(createLoadingView('Loading topics...'));
@@ -248,6 +249,8 @@ export const createLibraryView = (): HTMLElement => {
   );
 
   section.append(title, subtitle, difficultyRow, status, list);
+
   void updateTopicsList();
+
   return section;
 };

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -8,6 +8,91 @@ import { createLoadingView } from '../../components/ui/loading/loading';
 import { createErrorMessage } from '../../components/ui/error-message/error-message';
 import { fetchCompletedTopicIds } from '../../services/api/fetch-completed-topic-ids';
 import { getState } from '../../app/state/store';
+import { showModal } from '../../components/ui/modal/modal';
+import { hasRequiredResumeData } from '../../services/resumeActiveGame';
+import { getActiveGame } from '../../services/storageService';
+
+function isSameActiveGame(
+  activeGame: ReturnType<typeof getActiveGame>,
+  topicId: number,
+  difficulty: Difficulty
+): boolean {
+  if (!activeGame) return false;
+
+  return (
+    activeGame.topicId === topicId &&
+    activeGame.difficulty === difficulty &&
+    activeGame.round > 0
+  );
+}
+
+function getTopicTitleById(topicId: number): string {
+  const topics = getState().topics;
+
+  return (
+    topics.find((topic) => topic.id === topicId)?.name ?? `Topic #${topicId}`
+  );
+}
+
+async function confirmReplaceActiveGame(
+  difficulty: Difficulty | null | undefined,
+  topicTitle: string
+): Promise<boolean> {
+  const result = await showModal({
+    title: 'Start new game?',
+    messageHtml: `
+     <p>You already have an unfinished game:</p>
+      <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
+      <p>Starting a new game will replace your current progress.</p>
+    `,
+    showConfirm: true,
+    confirmText: 'Start new game',
+    cancelText: 'Cancel',
+  });
+
+  return result.confirmed;
+}
+
+function createTopicCard(
+  topic: Topic,
+  isCompleted: boolean,
+  onStart: (startBtn: HTMLButtonElement) => void
+): HTMLElement {
+  const card = createEl('div', {
+    className: `library-card${isCompleted ? ' is-completed' : ''}`,
+  });
+
+  const name = createEl('div', {
+    text: topic.name ?? `Topic #${topic.id}`,
+    className: 'library-card-title',
+  });
+
+  const actions = createEl('div', { className: 'library-card-actions' });
+
+  const startBtn = createButton(
+    'Start',
+    () => onStart(startBtn as HTMLButtonElement),
+    'btn',
+    isCompleted
+  );
+
+  if (isCompleted) {
+    const topicIcon = createEl('img', {
+      className: 'topic-icon',
+    }) as HTMLImageElement;
+
+    topicIcon.src = '/img/tick-mark.png';
+    topicIcon.alt = '';
+    topicIcon.setAttribute('aria-hidden', 'true');
+
+    actions.append(topicIcon);
+  }
+
+  actions.append(startBtn);
+  card.append(name, actions);
+
+  return card;
+}
 
 export const createLibraryView = (): HTMLElement => {
   const section = createEl('section', { className: 'page' });
@@ -65,61 +150,51 @@ export const createLibraryView = (): HTMLElement => {
     });
   };
 
-  // Создает карточку темы.
-  const renderTopicCard = (topic: Topic, isCompleted: boolean): HTMLElement => {
-    const card = createEl('div', {
-      className: `library-card${isCompleted ? ' is-completed' : ''}`,
-    });
+  const handleStartClick = async (
+    topicId: number,
+    startBtn: HTMLButtonElement
+  ): Promise<void> => {
+    const activeGame = getActiveGame();
 
-    const name = createEl('div', {
-      text: topic.name ?? `Topic #${topic.id}`,
-      className: 'library-card-title',
-    });
+    status.textContent = '';
+    status.classList.remove('is-error');
+    startBtn.disabled = true;
 
-    const actions = createEl('div', { className: 'library-card-actions' });
+    try {
+      if (isSameActiveGame(activeGame, topicId, difficulty)) {
+        navigate(ROUTES.Practice, true);
+        return;
+      }
 
-    const startBtn = createButton(
-      'Start',
-      async () => {
-        status.textContent = 'Starting practice...';
-        status.classList.remove('is-error');
-        startBtn.disabled = true;
+      if (activeGame && hasRequiredResumeData(activeGame)) {
+        const activeTopicTitle = getTopicTitleById(activeGame.topicId);
 
-        try {
-          await startNewGame({
-            topicId: topic.id,
-            difficulty,
-          });
+        const shouldReplace = await confirmReplaceActiveGame(
+          activeGame.difficulty,
+          activeTopicTitle
+        );
 
-          status.textContent = '';
-          navigate(ROUTES.Practice, true);
-        } catch (err: unknown) {
-          status.textContent =
-            err instanceof Error ? err.message : 'Failed to start game.';
-          status.classList.add('is-error');
-          startBtn.disabled = false;
+        if (!shouldReplace) {
+          return;
         }
-      },
-      'btn',
-      isCompleted
-    );
+      }
 
-    if (isCompleted) {
-      const topicIcon = createEl('img', {
-        className: 'topic-icon',
-      }) as HTMLImageElement;
+      status.textContent = 'Starting practice...';
 
-      topicIcon.src = '/img/tick-mark.png';
-      topicIcon.alt = '';
-      topicIcon.setAttribute('aria-hidden', 'true');
+      await startNewGame({
+        topicId,
+        difficulty,
+      });
 
-      actions.append(topicIcon);
+      status.textContent = '';
+      navigate(ROUTES.Practice, true);
+    } catch (err: unknown) {
+      status.textContent =
+        err instanceof Error ? err.message : 'Failed to start game.';
+      status.classList.add('is-error');
+    } finally {
+      startBtn.disabled = false;
     }
-
-    actions.append(startBtn);
-    card.append(name, actions);
-
-    return card;
   };
 
   // Загружает и обновляет список тем.
@@ -148,7 +223,13 @@ export const createLibraryView = (): HTMLElement => {
       const completedIds = new Set(completedTopicIds);
 
       topics.forEach((topic) => {
-        list.append(renderTopicCard(topic, completedIds.has(topic.id)));
+        list.append(
+          createTopicCard(
+            topic,
+            completedIds.has(topic.id),
+            (startBtn) => void handleStartClick(topic.id, startBtn)
+          )
+        );
       });
 
       saveTopics(topics);

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -160,11 +160,14 @@ export const createLibraryView = (): HTMLElement => {
     status.classList.remove('is-error');
     startBtn.disabled = true;
 
+    let shouldEnableButton = true;
+
     try {
       const activeGame = await getResumeCandidate();
 
       if (activeGame && isSameActiveGame(activeGame, topicId, difficulty)) {
         restoreGameState(activeGame);
+        shouldEnableButton = false;
         navigate(ROUTES.Practice, true);
         return;
       }
@@ -189,13 +192,16 @@ export const createLibraryView = (): HTMLElement => {
       });
 
       status.textContent = '';
+      shouldEnableButton = false;
       navigate(ROUTES.Practice, true);
     } catch (err: unknown) {
       status.textContent =
         err instanceof Error ? err.message : 'Failed to start game.';
       status.classList.add('is-error');
     } finally {
-      startBtn.disabled = false;
+      if (shouldEnableButton) {
+        startBtn.disabled = false;
+      }
     }
   };
 

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -18,7 +18,7 @@ import { createErrorMessage } from '../../components/ui/error-message/error-mess
 import { fetchCompletedTopicIds } from '../../services/api/fetch-completed-topic-ids';
 import { getState } from '../../app/state/store';
 import { showModal } from '../../components/ui/modal/modal';
-import { getResumeCandidate } from '../../services/resumeActiveGame';
+import { getResumeCandidate } from '../../services/resume-active-game';
 
 type GameState = AppState['game'];
 


### PR DESCRIPTION
## Описание

Обновлен сценарий старта игры из Library с учетом незавершенной активной игры.

Теперь при нажатии **Start**:
- если сохранена эта же незавершенная игра, сначала показывается confirm modal с предложением продолжить игру;
- если пользователь подтверждает, состояние восстанавливается и происходит переход в Practice;
- если сохранена другая незавершенная игра, перед запуском новой показывается confirm modal.

## Что сделано

- добавлена проверка активной игры через `getResumeCandidate()`
- для same active game добавлено подтверждение перед восстановлением сохраненного прогресса
- добавлено подтверждение перед заменой другой незавершенной игры
- исправлена логика кнопки **Start**, чтобы она не переактивировалась после успешного перехода
- обновлены тесты под новый flow старта и resume game

## Результат

Старт игры из Library стал согласован с логикой resume game и больше не восстанавливает и не перезаписывает незавершенный прогресс без явного подтверждения пользователя.

<img width="1470" height="956" alt="Screenshot 2026-04-09 at 18 08 33" src="https://github.com/user-attachments/assets/9591883d-f5a0-4d4c-9a98-c054303c32ec" />
