### PR TITLE
Refactor/rename text container classes

### DIFF
--- a/src/components/game/hintsLogic/show-side-panel.ts
+++ b/src/components/game/hintsLogic/show-side-panel.ts
@@ -9,7 +9,7 @@ export function showSidePanel(e: MouseEvent) {
     document.querySelector('.side-panel');
   if (!sidePanel) return;
 
-  const textContainer = sidePanel?.querySelector('.text-container');
+  const textContainer = sidePanel?.querySelector('.side-panel-text');
   if (!textContainer) return;
 
   const fallbackExplanation =

--- a/src/components/ui/final-screen/final-screen.scss
+++ b/src/components/ui/final-screen/final-screen.scss
@@ -23,7 +23,7 @@
   border-radius: v.$border-radius;
 }
 
-.text-container {
+.final-screen-text {
   width: 70%;
   color: v.$color-white;
 }

--- a/src/components/ui/final-screen/final-screen.ts
+++ b/src/components/ui/final-screen/final-screen.ts
@@ -58,7 +58,7 @@ export async function createFinalScreen() {
     const modalWindow = createEl('div', {
       className: 'final-screen-modal',
     }) as HTMLDivElement;
-    const textContainer = createEl('div', { className: 'text-container' });
+    const textContainer = createEl('div', { className: 'final-screen-text' });
     textContainer.innerHTML = text;
     const badgeContainer = createEl('span', { className: 'badge-container' });
     badgeContainer.innerHTML = achievementText;

--- a/src/components/ui/practice-card/side-panel/side-panel.scss
+++ b/src/components/ui/practice-card/side-panel/side-panel.scss
@@ -44,7 +44,8 @@
   font-family: v.$font-family-base;
 }
 
-.text-container {
+.side-panel-text {
+  color: v.$text-color;
   padding: v.$spacing-md;
 }
 

--- a/src/components/ui/practice-card/side-panel/side-panel.ts
+++ b/src/components/ui/practice-card/side-panel/side-panel.ts
@@ -25,7 +25,7 @@ export function createSidePanel(container: HTMLElement, card: HTMLElement) {
   const title = createEl('h2', { className: 'side-panel-title' });
   title.textContent = 'Explanation';
   const divider = createDivider();
-  const textContainer = createEl('div', { className: 'text-container' });
+  const textContainer = createEl('div', { className: 'side-panel-text' });
   sidePanel.append(closeButton, title, divider, textContainer);
   sidePanel.classList.add('closed');
   sidePanel.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Что сделано

Переименованы общие классы `text-container` в более конкретные, привязанные к компонентам.

## Зачем

Это убирает конфликт стилей между `side-panel` и `final-screen`, из-за которого текст отображался некорректно.

## Результат

Стили стали изолированнее, а названия классов - понятнее и читаемее.