### PR TITLE
Fix/practice refresh resume

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -122,8 +122,18 @@ export async function initApp(mount: HTMLElement): Promise<void> {
   });
 
   setNavigate(router.go);
+
+  const shouldResumeBeforeStart =
+    isAuthed() && window.location.pathname === ROUTES.Practice;
+
+  if (shouldResumeBeforeStart) {
+    await tryResumeGame();
+  }
+
   router.start();
 
-  await waitForPaint();
-  await tryResumeGame();
+  if (!shouldResumeBeforeStart && isAuthed()) {
+    await waitForPaint();
+    await tryResumeGame();
+  }
 }

--- a/src/pages/practice/practice.ts
+++ b/src/pages/practice/practice.ts
@@ -13,12 +13,20 @@ import { syncActiveGameToServer } from '../../services/syncActiveGame';
 export function createPracticeView(): HTMLElement {
   const section = createEl('section', { className: 'page practice-page' });
   section.append(createLoadingView('Loading questions...'));
+
   const state = getState();
   const topicId = state.game.topicId;
   const difficulty = state.game.difficulty;
+
   if (!difficulty) {
-    throw new Error('Difficulty is not selected');
+    section.replaceChildren(
+      createErrorMessage(
+        'No active game found. Please start a new game from the library.'
+      )
+    );
+    return section;
   }
+
   getQuestions(topicId, difficulty)
     .then(async (questions) => {
       if (!section.isConnected) return;
@@ -28,7 +36,6 @@ export function createPracticeView(): HTMLElement {
       if (!section.isConnected) return;
 
       const practiceCard = createPracticeCard();
-      section.append(practiceCard);
 
       section.replaceChildren(practiceCard);
       createSidePanel(section, practiceCard);


### PR DESCRIPTION
## Описание

Исправлен сценарий обновления страницы на `/practice`, при котором practice view мог рендериться раньше восстановления активной игры и падать с ошибкой из-за отсутствующего `difficulty`. PR также добавляет безопасную обработку случая, когда practice route открыт без валидного активного состояния игры.

## Что сделано

- в `app.ts` изменён порядок инициализации: на маршруте `/practice` попытка восстановления активной игры теперь выполняется до первого `router.start()`
- сохранено текущее поведение resume flow для остальных маршрутов
- в `practice.ts` убран аварийный `throw` при отсутствии `difficulty`
- вместо runtime error теперь показывается controlled error state через `createErrorMessage(...)`
- убран лишний `section.append(practiceCard)`, так как далее используется `replaceChildren(practiceCard)`

## Результат

- при refresh страницы `/practice` активная игра успевает восстановиться до первого рендера practice view
- предупреждение `Difficulty is not selected` больше не появляется в консоли
- при невалидном или отсутствующем состоянии игра не ломает страницу, а показывает понятное сообщение в UI
---
## Справочная информация
Ошибка консоли, решаемая данным PR (возникала при обновлении страницы `/practice`)
<img width="1470" height="956" alt="Screenshot 2026-04-10 at 14 53 51" src="https://github.com/user-attachments/assets/ce240771-f806-45d6-ad90-142b475251a5" />

