### PR TITLE
Fix/stale resume candidate

### DIFF
--- a/src/components/ui/final-screen/final-screen.ts
+++ b/src/components/ui/final-screen/final-screen.ts
@@ -73,9 +73,14 @@ export async function createFinalScreen() {
       handleRestartButton,
       'restart-btn'
     );
+    const handleLibraryButton = async () => {
+      await finishCurrentGame();
+      navigate(ROUTES.Library, true);
+    };
+
     const libraryButton = createButton(
       'Library',
-      () => navigate(ROUTES.Library, true),
+      handleLibraryButton,
       'library-btn'
     );
 

--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -47,6 +47,16 @@ import { createLibraryView } from './library';
 import { ROUTES } from '../../types';
 
 describe('createLibraryView', () => {
+  const resumeGameMock = {
+    topicId: 1,
+    difficulty: 'easy' as const,
+    round: 2,
+    score: 0,
+    usedHints: [],
+    wrongAnswers: [],
+    questions: [{ id: 1 }],
+  };
+
   beforeEach(() => {
     document.body.innerHTML = '';
     vi.clearAllMocks();
@@ -242,13 +252,8 @@ describe('createLibraryView', () => {
     });
 
     mocks.getResumeCandidate.mockResolvedValue({
-      topicId: 1,
-      difficulty: 'easy',
-      round: 2,
-      score: 0,
-      usedHints: [],
-      wrongAnswers: [],
-      questions: [{ id: 1 }],
+      game: resumeGameMock,
+      source: 'local',
     });
 
     mocks.showModal.mockResolvedValue({ confirmed: true });
@@ -301,13 +306,8 @@ describe('createLibraryView', () => {
     });
 
     mocks.getResumeCandidate.mockResolvedValue({
-      topicId: 1,
-      difficulty: 'easy',
-      round: 2,
-      score: 0,
-      usedHints: [],
-      wrongAnswers: [],
-      questions: [{ id: 1 }],
+      game: resumeGameMock,
+      source: 'local',
     });
 
     mocks.showModal.mockResolvedValue({ confirmed: true });
@@ -366,13 +366,8 @@ describe('createLibraryView', () => {
     });
 
     mocks.getResumeCandidate.mockResolvedValue({
-      topicId: 1,
-      difficulty: 'easy',
-      round: 2,
-      score: 0,
-      usedHints: [],
-      wrongAnswers: [],
-      questions: [{ id: 1 }],
+      game: resumeGameMock,
+      source: 'local',
     });
 
     mocks.showModal.mockResolvedValue({ confirmed: false });

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -182,7 +182,8 @@ export const createLibraryView = (): HTMLElement => {
     let shouldEnableButton = true;
 
     try {
-      const activeGame = await getResumeCandidate();
+      const activeCandidate = await getResumeCandidate();
+      const activeGame = activeCandidate?.game;
 
       if (activeGame && isSameActiveGame(activeGame, topicId, difficulty)) {
         const activeTopicTitle = getTopicTitleById(activeGame.topicId);

--- a/src/services/resume-active-game.ts
+++ b/src/services/resume-active-game.ts
@@ -234,17 +234,33 @@ export async function promptResumeGame(game: GameState): Promise<boolean> {
 /**
  * Загружает topics, если их еще нет в store.
  */
+let topicsLoadingPromise: Promise<void> | null = null;
+
+/**
+ * Загружает topics, если их еще нет в store.
+ * Параллельные вызовы переиспользуют один и тот же запрос.
+ */
 async function ensureTopicsLoaded(): Promise<void> {
   if (getState().topics.length > 0) {
     return;
   }
 
-  try {
-    const topics = await getTopics();
-    saveTopics(topics);
-  } catch (error) {
-    console.error('Failed to load topics while resuming game:', error);
+  if (topicsLoadingPromise) {
+    return topicsLoadingPromise;
   }
+
+  topicsLoadingPromise = (async () => {
+    try {
+      const topics = await getTopics();
+      saveTopics(topics);
+    } catch (error) {
+      console.error('Failed to load topics while resuming game:', error);
+    } finally {
+      topicsLoadingPromise = null;
+    }
+  })();
+
+  return topicsLoadingPromise;
 }
 
 /**

--- a/src/services/resume-active-game.ts
+++ b/src/services/resume-active-game.ts
@@ -8,10 +8,14 @@ import { getActiveGameByUser } from './api/active-games';
 import { getTopics } from './api/get-topics';
 import { removeActiveGameFromServer } from './sync-active-game';
 import { showModal } from '../components/ui/modal/modal';
+import { fetchCompletedTopicIds } from './api/fetch-completed-topic-ids';
 
 type GameState = AppState['game'];
 
 export type ResumeFlowResult = 'no-game' | 'resumed' | 'discarded';
+
+const validDifficulties = ['easy', 'medium', 'hard'] as const;
+type ValidDifficulty = (typeof validDifficulties)[number];
 
 /**
  * Проверяет, что usedHints существует
@@ -35,11 +39,16 @@ export async function getResumeCandidate(): Promise<GameState | null> {
   const localGame = getActiveGame();
 
   if (hasRequiredResumeData(localGame)) {
-    return localGame;
+    const isCompleted = await isCompletedResumeCandidate(localGame);
+
+    if (!isCompleted) {
+      return localGame;
+    }
+
+    await discardResumeCandidate();
+  } else {
+    clearActiveGame();
   }
-
-  clearActiveGame();
-
   const user = authService.getCurrentUser();
 
   if (!user) {
@@ -49,14 +58,23 @@ export async function getResumeCandidate(): Promise<GameState | null> {
   try {
     const serverGame = await getActiveGameByUser(user.id);
 
-    return hasRequiredResumeData(serverGame) ? serverGame : null;
+    if (!hasRequiredResumeData(serverGame)) {
+      return null;
+    }
+
+    const isCompleted = await isCompletedResumeCandidate(serverGame);
+
+    if (isCompleted) {
+      await discardResumeCandidate();
+      return null;
+    }
+
+    return serverGame;
   } catch (error) {
     console.error('Failed to load resume candidate from server:', error);
     return null;
   }
 }
-
-const validDifficulties = ['easy', 'medium', 'hard'] as const;
 
 /**
  * Проверяет, что в сохраненной игре есть
@@ -162,5 +180,39 @@ export async function runResumeGameFlow(): Promise<ResumeFlowResult> {
   } catch (error) {
     console.error('Resume game flow failed:', error);
     return 'no-game';
+  }
+}
+
+/**
+ * Проверяет, что в сохраненной игре указана
+ * корректная сложность для resume flow.
+ */
+function hasValidDifficulty(
+  difficulty: GameState['difficulty']
+): difficulty is ValidDifficulty {
+  return (
+    difficulty !== null &&
+    validDifficulties.includes(difficulty as ValidDifficulty)
+  );
+}
+
+/**
+ * Проверяет, не относится ли сохраненная игра
+ * к уже завершенной теме на текущей сложности.
+ */
+async function isCompletedResumeCandidate(game: GameState): Promise<boolean> {
+  if (!hasValidDifficulty(game.difficulty)) {
+    return false;
+  }
+
+  try {
+    const completedTopicIds = await fetchCompletedTopicIds(game.difficulty);
+    return completedTopicIds.includes(game.topicId);
+  } catch (error) {
+    console.error(
+      'Failed to validate resume candidate against completed topics:',
+      error
+    );
+    return false;
   }
 }

--- a/src/services/resume-active-game.ts
+++ b/src/services/resume-active-game.ts
@@ -99,6 +99,12 @@ async function isCompletedResumeCandidate(game: GameState): Promise<boolean> {
  * Сначала проверяет localStorage, потом сервер.
  */
 export async function getResumeCandidate(): Promise<GameState | null> {
+  const user = authService.getCurrentUser();
+
+  if (!user) {
+    return null;
+  }
+
   const localGame = getActiveGame();
 
   if (hasRequiredResumeData(localGame)) {
@@ -111,11 +117,6 @@ export async function getResumeCandidate(): Promise<GameState | null> {
     await discardResumeCandidate();
   } else {
     clearActiveGame();
-  }
-  const user = authService.getCurrentUser();
-
-  if (!user) {
-    return null;
   }
 
   try {

--- a/src/services/resume-active-game.ts
+++ b/src/services/resume-active-game.ts
@@ -27,6 +27,17 @@ type ResumeCandidate = {
   source: ResumeCandidateSource;
 };
 
+type ResumeLookupResult =
+  | { status: 'missing' }
+  | { status: 'invalid'; source: ResumeCandidateSource }
+  | { status: 'completed'; source: ResumeCandidateSource }
+  | { status: 'ready'; candidate: ResumeCandidate };
+
+type ResumeCandidateResolution = {
+  candidate: ResumeCandidate | null;
+  staleSources: ResumeCandidateSource[];
+};
+
 const validDifficulties: Difficulty[] = ['easy', 'medium', 'hard'];
 type ValidDifficulty = (typeof validDifficulties)[number];
 
@@ -100,82 +111,128 @@ async function isCompletedResumeCandidate(game: GameState): Promise<boolean> {
 }
 
 /**
- * Ищет сохраненную игру для продолжения в localStorage.
+ * Проверяет сохраненную игру в localStorage
+ * и возвращает результат в виде статуса resume candidate.
  */
-async function getLocalResumeCandidate(): Promise<ResumeCandidate | null> {
+async function checkLocalResumeCandidate(): Promise<ResumeLookupResult> {
   const localGame = getActiveGame();
 
   if (!localGame) {
-    return null;
+    return { status: 'missing' };
   }
 
   if (!hasRequiredResumeData(localGame)) {
-    discardLocalResumeCandidate();
-    return null;
+    return { status: 'invalid', source: 'local' };
   }
 
   const isCompleted = await isCompletedResumeCandidate(localGame);
 
   if (isCompleted) {
-    discardLocalResumeCandidate();
-    return null;
+    return { status: 'completed', source: 'local' };
   }
 
   return {
-    game: localGame,
-    source: 'local',
+    status: 'ready',
+    candidate: {
+      game: localGame,
+      source: 'local',
+    },
   };
 }
 
 /**
- * Ищет сохраненную игру для продолжения на сервере.
+ * Проверяет сохраненную игру на сервере
+ * и возвращает результат в виде статуса resume candidate.
  */
-async function getServerResumeCandidate(
+async function checkServerResumeCandidate(
   userId: string
-): Promise<ResumeCandidate | null> {
+): Promise<ResumeLookupResult> {
   try {
     const serverGame = await getActiveGameByUser(userId);
 
+    if (!serverGame) {
+      return { status: 'missing' };
+    }
+
     if (!hasRequiredResumeData(serverGame)) {
-      return null;
+      return { status: 'invalid', source: 'server' };
     }
 
     const isCompleted = await isCompletedResumeCandidate(serverGame);
 
     if (isCompleted) {
-      await discardServerResumeCandidate();
-      return null;
+      return { status: 'completed', source: 'server' };
     }
 
     return {
-      game: serverGame,
-      source: 'server',
+      status: 'ready',
+      candidate: {
+        game: serverGame,
+        source: 'server',
+      },
     };
   } catch (error) {
     console.error('Failed to load resume candidate from server:', error);
-    return null;
+    return { status: 'missing' };
   }
 }
 
 /**
- * Ищет resume candidate для продолжения игры.
- * Сначала проверяет localStorage, затем сервер
- * и возвращает игру вместе с источником.
+ * Проверяет, есть ли игра для продолжения.
+ * Возвращает найденную игру и источники,
+ * которые нужно очистить отдельно.
  */
-export async function getResumeCandidate(): Promise<ResumeCandidate | null> {
+async function resolveResumeCandidate(): Promise<ResumeCandidateResolution> {
   const user = authService.getCurrentUser();
 
   if (!user) {
-    return null;
+    return { candidate: null, staleSources: [] };
   }
 
-  const localCandidate = await getLocalResumeCandidate();
+  const staleSources: ResumeCandidateSource[] = [];
 
-  if (localCandidate) {
-    return localCandidate;
+  const localResult = await checkLocalResumeCandidate();
+
+  if (localResult.status === 'ready') {
+    return {
+      candidate: localResult.candidate,
+      staleSources,
+    };
   }
 
-  return getServerResumeCandidate(user.id);
+  if (localResult.status === 'invalid' || localResult.status === 'completed') {
+    staleSources.push(localResult.source);
+  }
+
+  const serverResult = await checkServerResumeCandidate(user.id);
+
+  if (serverResult.status === 'ready') {
+    return {
+      candidate: serverResult.candidate,
+      staleSources,
+    };
+  }
+
+  if (
+    serverResult.status === 'invalid' ||
+    serverResult.status === 'completed'
+  ) {
+    staleSources.push(serverResult.source);
+  }
+
+  return {
+    candidate: null,
+    staleSources,
+  };
+}
+
+/**
+ * Возвращает resume candidate для продолжения игры
+ * без очистки невалидных или устаревших данных.
+ */
+export async function getResumeCandidate(): Promise<ResumeCandidate | null> {
+  const { candidate } = await resolveResumeCandidate();
+  return candidate;
 }
 
 /**
@@ -209,6 +266,20 @@ async function discardResumeCandidate(
   }
 
   await discardServerResumeCandidate();
+}
+
+/**
+ * Удаляет resume candidate из нескольких источников.
+ * Повторяющиеся источники очищаются только один раз.
+ */
+async function discardResumeCandidates(
+  sources: ResumeCandidateSource[]
+): Promise<void> {
+  const uniqueSources = [...new Set(sources)];
+
+  for (const source of uniqueSources) {
+    await discardResumeCandidate(source);
+  }
 }
 
 /**
@@ -276,21 +347,23 @@ async function restoreResumedGame(game: GameState): Promise<void> {
  */
 export async function runResumeGameFlow(): Promise<ResumeFlowResult> {
   try {
-    const candidate = await getResumeCandidate();
+    const { candidate, staleSources } = await resolveResumeCandidate();
 
     if (!candidate) {
+      await discardResumeCandidates(staleSources);
       return 'no-game';
     }
 
     const shouldResume = await promptResumeGame(candidate.game);
 
     if (shouldResume) {
+      await discardResumeCandidates(staleSources);
       await restoreResumedGame(candidate.game);
       navigate(ROUTES.Practice, true);
       return 'resumed';
     }
 
-    await discardResumeCandidate(candidate.source);
+    await discardResumeCandidates([...staleSources, candidate.source]);
     return 'discarded';
   } catch (error) {
     console.error('Resume game flow failed:', error);

--- a/src/services/resume-active-game.ts
+++ b/src/services/resume-active-game.ts
@@ -20,6 +20,13 @@ type GameState = AppState['game'];
 
 export type ResumeFlowResult = 'no-game' | 'resumed' | 'discarded';
 
+type ResumeCandidateSource = 'local' | 'server';
+
+type ResumeCandidate = {
+  game: GameState;
+  source: ResumeCandidateSource;
+};
+
 const validDifficulties: Difficulty[] = ['easy', 'medium', 'hard'];
 type ValidDifficulty = (typeof validDifficulties)[number];
 
@@ -63,9 +70,7 @@ export function hasRequiredResumeData(
 
   return Boolean(
     game.topicId > 0 &&
-    validDifficulties.includes(
-      game.difficulty as (typeof validDifficulties)[number]
-    ) &&
+    hasValidDifficulty(game.difficulty) &&
     game.round > 0 &&
     Array.isArray(game.questions) &&
     game.questions.length > 0 &&
@@ -95,32 +100,41 @@ async function isCompletedResumeCandidate(game: GameState): Promise<boolean> {
 }
 
 /**
- * Ищет сохраненную игру для продолжения.
- * Сначала проверяет localStorage, потом сервер.
+ * Ищет сохраненную игру для продолжения в localStorage.
  */
-export async function getResumeCandidate(): Promise<GameState | null> {
-  const user = authService.getCurrentUser();
+async function getLocalResumeCandidate(): Promise<ResumeCandidate | null> {
+  const localGame = getActiveGame();
 
-  if (!user) {
+  if (!localGame) {
     return null;
   }
 
-  const localGame = getActiveGame();
-
-  if (hasRequiredResumeData(localGame)) {
-    const isCompleted = await isCompletedResumeCandidate(localGame);
-
-    if (!isCompleted) {
-      return localGame;
-    }
-
-    await discardResumeCandidate();
-  } else {
-    clearActiveGame();
+  if (!hasRequiredResumeData(localGame)) {
+    discardLocalResumeCandidate();
+    return null;
   }
 
+  const isCompleted = await isCompletedResumeCandidate(localGame);
+
+  if (isCompleted) {
+    discardLocalResumeCandidate();
+    return null;
+  }
+
+  return {
+    game: localGame,
+    source: 'local',
+  };
+}
+
+/**
+ * Ищет сохраненную игру для продолжения на сервере.
+ */
+async function getServerResumeCandidate(
+  userId: string
+): Promise<ResumeCandidate | null> {
   try {
-    const serverGame = await getActiveGameByUser(user.id);
+    const serverGame = await getActiveGameByUser(userId);
 
     if (!hasRequiredResumeData(serverGame)) {
       return null;
@@ -129,11 +143,14 @@ export async function getResumeCandidate(): Promise<GameState | null> {
     const isCompleted = await isCompletedResumeCandidate(serverGame);
 
     if (isCompleted) {
-      await discardResumeCandidate();
+      await discardServerResumeCandidate();
       return null;
     }
 
-    return serverGame;
+    return {
+      game: serverGame,
+      source: 'server',
+    };
   } catch (error) {
     console.error('Failed to load resume candidate from server:', error);
     return null;
@@ -141,16 +158,57 @@ export async function getResumeCandidate(): Promise<GameState | null> {
 }
 
 /**
- * Удаляет сохраненную игру локально и на сервере.
+ * Ищет resume candidate для продолжения игры.
+ * Сначала проверяет localStorage, затем сервер
+ * и возвращает игру вместе с источником.
  */
-export async function discardResumeCandidate(): Promise<void> {
-  clearActiveGame();
+export async function getResumeCandidate(): Promise<ResumeCandidate | null> {
+  const user = authService.getCurrentUser();
 
+  if (!user) {
+    return null;
+  }
+
+  const localCandidate = await getLocalResumeCandidate();
+
+  if (localCandidate) {
+    return localCandidate;
+  }
+
+  return getServerResumeCandidate(user.id);
+}
+
+/**
+ * Удаляет сохраненную игру локально.
+ */
+function discardLocalResumeCandidate(): void {
+  clearActiveGame();
+}
+
+/**
+ * Удаляет сохраненную игру на сервере.
+ */
+async function discardServerResumeCandidate(): Promise<void> {
   try {
     await removeActiveGameFromServer();
   } catch (error) {
     console.error('Failed to remove active game from server:', error);
   }
+}
+
+/**
+ * Удаляет resume candidate из указанного источника:
+ * localStorage или сервера.
+ */
+async function discardResumeCandidate(
+  source: ResumeCandidateSource
+): Promise<void> {
+  if (source === 'local') {
+    discardLocalResumeCandidate();
+    return;
+  }
+
+  await discardServerResumeCandidate();
 }
 
 /**
@@ -202,21 +260,21 @@ async function restoreResumedGame(game: GameState): Promise<void> {
  */
 export async function runResumeGameFlow(): Promise<ResumeFlowResult> {
   try {
-    const game = await getResumeCandidate();
+    const candidate = await getResumeCandidate();
 
-    if (!game) {
+    if (!candidate) {
       return 'no-game';
     }
 
-    const shouldResume = await promptResumeGame(game);
+    const shouldResume = await promptResumeGame(candidate.game);
 
     if (shouldResume) {
-      await restoreResumedGame(game);
+      await restoreResumedGame(candidate.game);
       navigate(ROUTES.Practice, true);
       return 'resumed';
     }
 
-    await discardResumeCandidate();
+    await discardResumeCandidate(candidate.source);
     return 'discarded';
   } catch (error) {
     console.error('Resume game flow failed:', error);

--- a/src/services/resume-active-game.ts
+++ b/src/services/resume-active-game.ts
@@ -1,4 +1,10 @@
-import { HINT_KEYS, ROUTES, type AppState, type HintCounter } from '../types';
+import {
+  HINT_KEYS,
+  ROUTES,
+  type AppState,
+  type Difficulty,
+  type HintCounter,
+} from '../types';
 import { navigate } from '../app/navigation';
 import { restoreGameState, saveTopics } from '../app/state/actions';
 import { getState } from '../app/state/store';
@@ -14,8 +20,21 @@ type GameState = AppState['game'];
 
 export type ResumeFlowResult = 'no-game' | 'resumed' | 'discarded';
 
-const validDifficulties = ['easy', 'medium', 'hard'] as const;
+const validDifficulties: Difficulty[] = ['easy', 'medium', 'hard'];
 type ValidDifficulty = (typeof validDifficulties)[number];
+
+/**
+ * Проверяет, что в сохраненной игре указана
+ * корректная сложность для resume flow.
+ */
+function hasValidDifficulty(
+  difficulty: GameState['difficulty']
+): difficulty is ValidDifficulty {
+  return (
+    difficulty !== null &&
+    validDifficulties.includes(difficulty as ValidDifficulty)
+  );
+}
 
 /**
  * Проверяет, что usedHints существует
@@ -29,6 +48,50 @@ function hasValidUsedHints(
   }
 
   return HINT_KEYS.every((key) => typeof usedHints[key] === 'number');
+}
+
+/**
+ * Проверяет, что в сохраненной игре есть
+ * все обязательные данные для корректного resume.
+ */
+export function hasRequiredResumeData(
+  game: GameState | null | undefined
+): game is GameState {
+  if (!game) {
+    return false;
+  }
+
+  return Boolean(
+    game.topicId > 0 &&
+    validDifficulties.includes(
+      game.difficulty as (typeof validDifficulties)[number]
+    ) &&
+    game.round > 0 &&
+    Array.isArray(game.questions) &&
+    game.questions.length > 0 &&
+    hasValidUsedHints(game.usedHints)
+  );
+}
+
+/**
+ * Проверяет, не относится ли сохраненная игра
+ * к уже завершенной теме на текущей сложности.
+ */
+async function isCompletedResumeCandidate(game: GameState): Promise<boolean> {
+  if (!hasValidDifficulty(game.difficulty)) {
+    return false;
+  }
+
+  try {
+    const completedTopicIds = await fetchCompletedTopicIds(game.difficulty);
+    return completedTopicIds.includes(game.topicId);
+  } catch (error) {
+    console.error(
+      'Failed to validate resume candidate against completed topics:',
+      error
+    );
+    return false;
+  }
 }
 
 /**
@@ -77,26 +140,16 @@ export async function getResumeCandidate(): Promise<GameState | null> {
 }
 
 /**
- * Проверяет, что в сохраненной игре есть
- * все обязательные данные для корректного resume.
+ * Удаляет сохраненную игру локально и на сервере.
  */
-export function hasRequiredResumeData(
-  game: GameState | null | undefined
-): game is GameState {
-  if (!game) {
-    return false;
-  }
+export async function discardResumeCandidate(): Promise<void> {
+  clearActiveGame();
 
-  return Boolean(
-    game.topicId > 0 &&
-    validDifficulties.includes(
-      game.difficulty as (typeof validDifficulties)[number]
-    ) &&
-    game.round > 0 &&
-    Array.isArray(game.questions) &&
-    game.questions.length > 0 &&
-    hasValidUsedHints(game.usedHints)
-  );
+  try {
+    await removeActiveGameFromServer();
+  } catch (error) {
+    console.error('Failed to remove active game from server:', error);
+  }
 }
 
 /**
@@ -117,19 +170,6 @@ export async function promptResumeGame(game: GameState): Promise<boolean> {
   });
 
   return result.confirmed;
-}
-
-/**
- * Удаляет сохраненную игру локально и на сервере.
- */
-export async function discardResumeCandidate(): Promise<void> {
-  clearActiveGame();
-
-  try {
-    await removeActiveGameFromServer();
-  } catch (error) {
-    console.error('Failed to remove active game from server:', error);
-  }
 }
 
 /**
@@ -180,39 +220,5 @@ export async function runResumeGameFlow(): Promise<ResumeFlowResult> {
   } catch (error) {
     console.error('Resume game flow failed:', error);
     return 'no-game';
-  }
-}
-
-/**
- * Проверяет, что в сохраненной игре указана
- * корректная сложность для resume flow.
- */
-function hasValidDifficulty(
-  difficulty: GameState['difficulty']
-): difficulty is ValidDifficulty {
-  return (
-    difficulty !== null &&
-    validDifficulties.includes(difficulty as ValidDifficulty)
-  );
-}
-
-/**
- * Проверяет, не относится ли сохраненная игра
- * к уже завершенной теме на текущей сложности.
- */
-async function isCompletedResumeCandidate(game: GameState): Promise<boolean> {
-  if (!hasValidDifficulty(game.difficulty)) {
-    return false;
-  }
-
-  try {
-    const completedTopicIds = await fetchCompletedTopicIds(game.difficulty);
-    return completedTopicIds.includes(game.topicId);
-  } catch (error) {
-    console.error(
-      'Failed to validate resume candidate against completed topics:',
-      error
-    );
-    return false;
   }
 }


### PR DESCRIPTION
## Описание

Исправлен ложный сценарий resume game, при котором модалка с предложением продолжить незавершенную игру могла появляться после завершенной игры или даже до авторизации пользователя.

## Что сделано

- в `final-screen.ts` добавлена очистка active game перед переходом в `Library`
- в `resume-active-game.ts` добавлен guard на completed topics, чтобы завершенная игра не считалась валидным resume candidate
- в `getResumeCandidate()` изменен порядок проверок: resume flow больше не срабатывает для guest user
- в `resume-active-game.ts` упорядочены helper functions для более читаемой структуры файла

## Результат

- после завершения игры stale active game больше не должна оставаться при переходе с final screen
- completed topic больше не вызывает ложную resume modal после refresh
- до логина модалка resume game больше не показывается
- файл `resume-active-game.ts` стал проще читать и поддерживать