### PR TITLE
refactor: extract library modals and update topic wording

### DIFF
--- a/src/pages/library/library-resume-modals.ts
+++ b/src/pages/library/library-resume-modals.ts
@@ -1,0 +1,40 @@
+import { showModal } from '../../components/ui/modal/modal';
+import type { Difficulty } from '../../types';
+
+export async function confirmReplaceActiveTopic(
+  difficulty: Difficulty | null | undefined,
+  topicTitle: string
+): Promise<boolean> {
+  const result = await showModal({
+    title: 'Start new topic?',
+    messageHtml: `
+        <p>You already have an unfinished topic:</p>
+        <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
+        <p>Starting a new topic will replace your current progress.</p>
+  `,
+    showConfirm: true,
+    confirmText: 'Start new topic',
+    cancelText: 'Cancel',
+  });
+
+  return result.confirmed;
+}
+
+export async function confirmContinueSameTopic(
+  difficulty: Difficulty | null | undefined,
+  topicTitle: string
+): Promise<boolean> {
+  const result = await showModal({
+    title: 'Continue previous topic?',
+    messageHtml: `
+        <p>You already have an unfinished topic:</p>
+        <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
+        <p>Do you want to continue your previous progress?</p>
+  `,
+    showConfirm: true,
+    confirmText: 'Continue topic',
+    cancelText: 'Cancel',
+  });
+
+  return result.confirmed;
+}

--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -270,7 +270,7 @@ describe('createLibraryView', () => {
     await waitFor(() => {
       expect(mocks.showModal).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: 'Continue previous game?',
+          title: 'Continue previous topic?',
           messageHtml: expect.stringContaining('HTML'),
         })
       );
@@ -341,8 +341,9 @@ describe('createLibraryView', () => {
 
     expect(mocks.showModal).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Start new game?',
+        title: 'Start new topic?',
         messageHtml: expect.stringContaining('HTML'),
+        confirmText: 'Start new topic',
       })
     );
   });

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -25,7 +25,7 @@ import {
 
 type GameState = AppState['game'];
 
-function isSameActiveGame(
+function isSameActiveTopic(
   activeGame: GameState,
   topicId: number,
   difficulty: Difficulty
@@ -150,7 +150,7 @@ export const createLibraryView = (): HTMLElement => {
       const activeCandidate = await getResumeCandidate();
       const activeGame = activeCandidate?.game;
 
-      if (activeGame && isSameActiveGame(activeGame, topicId, difficulty)) {
+      if (activeGame && isSameActiveTopic(activeGame, topicId, difficulty)) {
         const activeTopicTitle = getTopicTitleById(activeGame.topicId);
         const shouldContinue = await confirmContinueSameTopic(
           activeGame.difficulty,
@@ -191,7 +191,7 @@ export const createLibraryView = (): HTMLElement => {
       navigate(ROUTES.Practice, true);
     } catch (err: unknown) {
       status.textContent =
-        err instanceof Error ? err.message : 'Failed to start game.';
+        err instanceof Error ? err.message : 'Failed to start topic.';
       status.classList.add('is-error');
     } finally {
       if (shouldEnableButton) {

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -17,8 +17,11 @@ import { createLoadingView } from '../../components/ui/loading/loading';
 import { createErrorMessage } from '../../components/ui/error-message/error-message';
 import { fetchCompletedTopicIds } from '../../services/api/fetch-completed-topic-ids';
 import { getState } from '../../app/state/store';
-import { showModal } from '../../components/ui/modal/modal';
 import { getResumeCandidate } from '../../services/resume-active-game';
+import {
+  confirmContinueSameTopic,
+  confirmReplaceActiveTopic,
+} from './library-resume-modals.ts';
 
 type GameState = AppState['game'];
 
@@ -36,44 +39,6 @@ function getTopicTitleById(topicId: number): string {
   return (
     topics.find((topic) => topic.id === topicId)?.name ?? `Topic #${topicId}`
   );
-}
-
-async function confirmReplaceActiveGame(
-  difficulty: Difficulty | null | undefined,
-  topicTitle: string
-): Promise<boolean> {
-  const result = await showModal({
-    title: 'Start new game?',
-    messageHtml: `
-      <p>You already have an unfinished game:</p>
-      <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
-      <p>Starting a new game will replace your current progress.</p>
-`,
-    showConfirm: true,
-    confirmText: 'Start new game',
-    cancelText: 'Cancel',
-  });
-
-  return result.confirmed;
-}
-
-async function confirmContinueSameGame(
-  difficulty: Difficulty | null | undefined,
-  topicTitle: string
-): Promise<boolean> {
-  const result = await showModal({
-    title: 'Continue previous game?',
-    messageHtml: `
-      <p>You already have an unfinished game:</p>
-      <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
-      <p>Do you want to continue your previous progress?</p>
-`,
-    showConfirm: true,
-    confirmText: 'Continue game',
-    cancelText: 'Cancel',
-  });
-
-  return result.confirmed;
 }
 
 function createTopicCard(
@@ -187,7 +152,7 @@ export const createLibraryView = (): HTMLElement => {
 
       if (activeGame && isSameActiveGame(activeGame, topicId, difficulty)) {
         const activeTopicTitle = getTopicTitleById(activeGame.topicId);
-        const shouldContinue = await confirmContinueSameGame(
+        const shouldContinue = await confirmContinueSameTopic(
           activeGame.difficulty,
           activeTopicTitle
         );
@@ -204,7 +169,7 @@ export const createLibraryView = (): HTMLElement => {
 
       if (activeGame) {
         const activeTopicTitle = getTopicTitleById(activeGame.topicId);
-        const shouldReplace = await confirmReplaceActiveGame(
+        const shouldReplace = await confirmReplaceActiveTopic(
           activeGame.difficulty,
           activeTopicTitle
         );


### PR DESCRIPTION
## Описание

Конфигурации модального окна страницы Library вынесены в отдельный вспомогательный файл, а формулировка **game** заменена на **topic** там, где это лучше отражает реальный процесс.

## Что изменилось

- логика модального окна Library перемещена в отдельный вспомогательный файл
- обновлены заголовок модального окна, текст и надписи на кнопках: **Start new game** заменено на **Start new topic**
- существующее поведение начала/продолжения (start/resume) осталось без изменений

## Результат

Страница Library стала чище, а текст в модальном окне теперь точнее соответствует логике приложения: одна игра состоит из нескольких тем в пределах выбранного уровня сложности.

<img width="1470" height="956" alt="Screenshot 2026-04-12 at 20 20 28" src="https://github.com/user-attachments/assets/43d09a1b-edf6-49ca-9cf8-be20c564c35d" />
