### PR TITLE
fix: preserve selected library difficulty after refresh

### DIFF
--- a/src/app/state/actions.ts
+++ b/src/app/state/actions.ts
@@ -38,6 +38,21 @@ export function toggleTheme(): void {
   setTheme(prev.ui.theme === 'light' ? 'dark' : 'light');
 }
 
+export function setLibraryDifficulty(difficulty: Difficulty): void {
+  const prev = getState();
+
+  setState(
+    {
+      ...prev,
+      ui: {
+        ...prev.ui,
+        selectedLibraryDifficulty: difficulty,
+      },
+    },
+    { saveGameToStorage: false }
+  );
+}
+
 export function setActiveRoute(route: RoutePath): void {
   const prev = getState();
 

--- a/src/app/state/store.ts
+++ b/src/app/state/store.ts
@@ -8,9 +8,13 @@ const initialUIState: UIState = {
   activeRoute: ROUTES.Landing,
   isNavOpen: false,
   onboardingSeen: false,
+  selectedLibraryDifficulty: 'easy',
 };
 
-function loadUIState(): Pick<UIState, 'theme' | 'onboardingSeen'> {
+function loadUIState(): Pick<
+  UIState,
+  'theme' | 'onboardingSeen' | 'selectedLibraryDifficulty'
+> {
   try {
     const persisted = localStorage.getItem(UI_STORAGE_KEY);
 
@@ -18,6 +22,7 @@ function loadUIState(): Pick<UIState, 'theme' | 'onboardingSeen'> {
       return {
         theme: initialUIState.theme,
         onboardingSeen: initialUIState.onboardingSeen,
+        selectedLibraryDifficulty: initialUIState.selectedLibraryDifficulty,
       };
     }
 
@@ -26,12 +31,18 @@ function loadUIState(): Pick<UIState, 'theme' | 'onboardingSeen'> {
     return {
       theme: parsed.theme === 'dark' ? 'dark' : 'light',
       onboardingSeen: Boolean(parsed.onboardingSeen),
+      selectedLibraryDifficulty:
+        parsed.selectedLibraryDifficulty === 'medium' ||
+        parsed.selectedLibraryDifficulty === 'hard'
+          ? parsed.selectedLibraryDifficulty
+          : 'easy',
     };
   } catch (error) {
     console.error('Failed to load UI state from localStorage:', error);
     return {
       theme: initialUIState.theme,
       onboardingSeen: initialUIState.onboardingSeen,
+      selectedLibraryDifficulty: initialUIState.selectedLibraryDifficulty,
     };
   }
 }
@@ -43,6 +54,7 @@ function saveUIState(ui: UIState): void {
       JSON.stringify({
         theme: ui.theme,
         onboardingSeen: ui.onboardingSeen,
+        selectedLibraryDifficulty: ui.selectedLibraryDifficulty,
       })
     );
   } catch (error) {

--- a/src/components/ui/practice-card/practice-card.test.ts
+++ b/src/components/ui/practice-card/practice-card.test.ts
@@ -70,6 +70,7 @@ const createMockState = (
     activeRoute: '/' as const,
     isNavOpen: false,
     onboardingSeen: true,
+    selectedLibraryDifficulty: 'easy',
   },
 });
 

--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   startNewGame: vi.fn(),
   saveTopics: vi.fn(),
   restoreGameState: vi.fn(),
+  setLibraryDifficulty: vi.fn(),
   getState: vi.fn(),
   fetchCompletedTopicIds: vi.fn(),
   showModal: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock('../../app/state/actions', () => ({
   startNewGame: mocks.startNewGame,
   saveTopics: mocks.saveTopics,
   restoreGameState: mocks.restoreGameState,
+  setLibraryDifficulty: mocks.setLibraryDifficulty,
 }));
 
 vi.mock('../../components/ui/modal/modal', () => ({
@@ -74,6 +76,13 @@ describe('createLibraryView', () => {
       },
       topics: [],
       isLoading: false,
+      ui: {
+        theme: 'light',
+        activeRoute: ROUTES.Library,
+        isNavOpen: false,
+        onboardingSeen: false,
+        selectedLibraryDifficulty: 'easy',
+      },
     });
 
     mocks.fetchCompletedTopicIds.mockResolvedValue([]);
@@ -249,6 +258,13 @@ describe('createLibraryView', () => {
       },
       topics: [{ id: 1, name: 'HTML' }],
       isLoading: false,
+      ui: {
+        theme: 'light',
+        activeRoute: ROUTES.Library,
+        isNavOpen: false,
+        onboardingSeen: false,
+        selectedLibraryDifficulty: 'easy',
+      },
     });
 
     mocks.getResumeCandidate.mockResolvedValue({
@@ -303,6 +319,13 @@ describe('createLibraryView', () => {
       },
       topics: [{ id: 1, name: 'HTML' }],
       isLoading: false,
+      ui: {
+        theme: 'light',
+        activeRoute: ROUTES.Library,
+        isNavOpen: false,
+        onboardingSeen: false,
+        selectedLibraryDifficulty: 'easy',
+      },
     });
 
     mocks.getResumeCandidate.mockResolvedValue({
@@ -363,6 +386,13 @@ describe('createLibraryView', () => {
       },
       topics: [{ id: 1, name: 'HTML' }],
       isLoading: false,
+      ui: {
+        theme: 'light',
+        activeRoute: ROUTES.Library,
+        isNavOpen: false,
+        onboardingSeen: false,
+        selectedLibraryDifficulty: 'easy',
+      },
     });
 
     mocks.getResumeCandidate.mockResolvedValue({
@@ -415,6 +445,42 @@ describe('createLibraryView', () => {
     await waitFor(() => {
       expect(screen.getByText('Start failed')).toBeInTheDocument();
       expect(startBtn).not.toBeDisabled();
+    });
+  });
+
+  test('restores selected library difficulty after refresh', async () => {
+    mocks.getState.mockReturnValue({
+      user: null,
+      game: {
+        topicId: 0,
+        difficulty: null,
+        round: 0,
+        score: 0,
+        usedHints: [],
+        wrongAnswers: [],
+        questions: [],
+      },
+      topics: [],
+      isLoading: false,
+      ui: {
+        theme: 'light',
+        activeRoute: ROUTES.Library,
+        isNavOpen: false,
+        onboardingSeen: false,
+        selectedLibraryDifficulty: 'medium',
+      },
+    });
+
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+
+    const view = createLibraryView();
+    document.body.append(view);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Medium' })).toHaveClass(
+        'is-active'
+      );
+      expect(mocks.fetchCompletedTopicIds).toHaveBeenCalledWith('medium');
     });
   });
 });

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -12,6 +12,7 @@ import {
   restoreGameState,
   saveTopics,
   startNewGame,
+  setLibraryDifficulty,
 } from '../../app/state/actions';
 import { createLoadingView } from '../../components/ui/loading/loading';
 import { createErrorMessage } from '../../components/ui/error-message/error-message';
@@ -129,7 +130,7 @@ export const createLibraryView = (): HTMLElement => {
     className: 'library-subtitle',
   });
 
-  let difficulty: Difficulty = getState().game.difficulty || 'easy';
+  let difficulty: Difficulty = getState().ui.selectedLibraryDifficulty;
 
   const difficultyRow = createEl('div', { className: 'library-difficulty' });
 
@@ -140,7 +141,9 @@ export const createLibraryView = (): HTMLElement => {
 
   const handleDifficultyChange = (key: Difficulty) => {
     if (difficulty === key) return;
+
     difficulty = key;
+    setLibraryDifficulty(key);
     void updateTopicsList();
   };
 

--- a/src/pages/practice/practice.test.ts
+++ b/src/pages/practice/practice.test.ts
@@ -45,6 +45,7 @@ const createMockState = (
     activeRoute: '/',
     isNavOpen: false,
     onboardingSeen: true,
+    selectedLibraryDifficulty: 'easy',
   },
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type UIState = {
   activeRoute: RoutePath;
   isNavOpen: boolean;
   onboardingSeen: boolean;
+  selectedLibraryDifficulty: Difficulty;
 };
 
 type GameState = {


### PR DESCRIPTION
## Описание

Исправлено поведение страницы `/library` при обновлении экрана.

Раньше, если пользователь выбирал `medium` или `hard` и обновлял страницу, после перезагрузки Library всегда открывалась с уровнем сложности `easy`.

## Что сделано

- сохранена выбранная сложность Library в UI state
- восстановление выбранной сложности теперь работает после refresh
- логика active game и resume flow не изменялась
- обновлены тесты для нового поведения

## Результат

После обновления страницы `/library` остается выбранный пользователем уровень сложности, а список топиков загружается для него корректно.