### PR TITLE
feature: add dark theme support for library cards

### DIFF
--- a/src/pages/library/library.scss
+++ b/src/pages/library/library.scss
@@ -3,11 +3,12 @@
 
 .library-title {
   margin: 0;
+  color: var(--text-color, v.$text-color);
 }
 
 .library-subtitle {
   margin: 0;
-  color: v.$text-light;
+  color: var(--text-light-color, v.$text-light);
   font-size: v.$font-size-base;
 }
 
@@ -19,14 +20,14 @@
 }
 
 .library-difficulty-label {
-  color: v.$text-light;
+  color: var(--text-light-color, v.$text-light);
   font-size: v.$font-size-base;
 }
 
 .library-diff-btn {
-  background: v.$secondary-color;
-  color: v.$text-color;
-  border: 1px solid v.$border-color;
+  background: var(--surface-muted, v.$secondary-color);
+  color: var(--text-color, v.$text-color);
+  border: 1px solid var(--border-color, v.$border-color);
 
   &.is-active {
     background: v.$primary-color;
@@ -46,10 +47,10 @@
 }
 
 .library-card {
-  background: v.$color-white;
-  border: 1px solid v.$border-color;
+  background: var(--library-card-bg, v.$color-white);
+  border: 1px solid var(--library-card-border, v.$border-color);
   border-radius: v.$border-radius;
-  box-shadow: v.$shadow-default;
+  box-shadow: var(--library-card-shadow, v.$shadow-default);
   padding: v.$spacing-md;
 
   @include m.flex(column, flex-start, stretch);
@@ -58,7 +59,7 @@
 
 .library-card.is-completed {
   opacity: v.$modal-overlay-opacity;
-  background-color: v.$border-color;
+  background-color: var(--library-card-completed-bg, v.$border-color);
 }
 
 .topic-icon {
@@ -69,7 +70,7 @@
 
 .library-card-title {
   font-size: v.$font-size-lg;
-  color: v.$text-color;
+  color: var(--library-card-title-color, v.$text-color);
 }
 
 .library-card-actions {
@@ -85,7 +86,7 @@
 }
 
 .library-status {
-  color: v.$text-light;
+  color: var(--text-light-color, v.$text-light);
   font-size: v.$font-size-base;
 
   &.is-error {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -22,6 +22,12 @@
   --text-light-color: #c8cfdd;
   --border-color: #3a4252;
   --accent-color: #8ea2ff;
+
+  --library-card-bg: #252b36;
+  --library-card-border: #3a4252;
+  --library-card-title-color: #f5f7fb;
+  --library-card-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  --library-card-completed-bg: #313a5c;
 }
 
 body {


### PR DESCRIPTION
## Описание
Добавлена поддержка темной темы для карточек на странице Library.

## Результат
Страница Library теперь корректно выглядит в темной теме, при этом текущее поведение светлой темы сохранено.

<img width="1470" height="956" alt="Screenshot 2026-04-12 at 22 10 43" src="https://github.com/user-attachments/assets/56716245-524e-4a01-a718-3a2b71355557" />
