### PR TITLE
Feature/library active topic continue

### DIFF
--- a/src/pages/library/library-resume-modals.ts
+++ b/src/pages/library/library-resume-modals.ts
@@ -8,10 +8,10 @@ export async function confirmReplaceActiveTopic(
   const result = await showModal({
     title: 'Start new topic?',
     messageHtml: `
-        <p>You already have an unfinished topic:</p>
-        <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
-        <p>Starting a new topic will replace your current progress.</p>
-  `,
+      <p>You already have an unfinished topic:</p>
+      <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
+      <p>Starting a new topic will replace your current progress.</p>
+    `,
     showConfirm: true,
     confirmText: 'Start new topic',
     cancelText: 'Cancel',
@@ -20,19 +20,19 @@ export async function confirmReplaceActiveTopic(
   return result.confirmed;
 }
 
-export async function confirmContinueSameTopic(
+export async function confirmRestartActiveTopic(
   difficulty: Difficulty | null | undefined,
   topicTitle: string
 ): Promise<boolean> {
   const result = await showModal({
-    title: 'Continue previous topic?',
+    title: 'Start topic from the beginning?',
     messageHtml: `
-        <p>You already have an unfinished topic:</p>
-        <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
-        <p>Do you want to continue your previous progress?</p>
-  `,
+      <p>You already have unfinished progress in:</p>
+      <p><strong>${topicTitle}</strong> (${difficulty ?? 'another difficulty'})</p>
+      <p>Starting again will reset your current progress for this topic.</p>
+    `,
     showConfirm: true,
-    confirmText: 'Continue topic',
+    confirmText: 'Start over',
     cancelText: 'Cancel',
   });
 

--- a/src/pages/library/library.scss
+++ b/src/pages/library/library.scss
@@ -57,6 +57,24 @@
   gap: v.$spacing-sm;
 }
 
+.library-card-header {
+  @include m.flex(row, space-between, center);
+  gap: v.$spacing-sm;
+  flex-wrap: wrap;
+}
+
+.library-card-title {
+  font-size: v.$font-size-lg;
+  color: var(--library-card-title-color, v.$text-color);
+  min-width: 0;
+}
+
+.library-topic-badge {
+  color: var(--text-light-color, v.$text-light);
+  font-size: v.$font-size-sm;
+  white-space: nowrap;
+}
+
 .library-card.is-completed {
   opacity: v.$modal-overlay-opacity;
   background-color: var(--library-card-completed-bg, v.$border-color);
@@ -68,17 +86,16 @@
   object-fit: contain;
 }
 
-.library-card-title {
-  font-size: v.$font-size-lg;
-  color: var(--library-card-title-color, v.$text-color);
-}
-
 .library-card-actions {
   @include m.flex(row, space-between, center);
+  gap: v.$spacing-sm;
+}
 
-  .btn {
-    margin-left: auto;
-  }
+.library-card-actions-right {
+  @include m.flex(row, flex-end, center);
+  gap: v.$spacing-sm;
+  margin-left: auto;
+  flex-wrap: wrap;
 }
 
 .library-list-status.is-error {

--- a/src/pages/library/library.test.ts
+++ b/src/pages/library/library.test.ts
@@ -242,7 +242,62 @@ describe('createLibraryView', () => {
     });
   });
 
-  test('shows confirmation modal and restores same active game after confirmation', async () => {
+  test('shows continue button and restores same active topic without confirmation', async () => {
+    mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
+
+    mocks.getState.mockReturnValue({
+      user: null,
+      game: {
+        topicId: 0,
+        difficulty: '',
+        round: 0,
+        score: 0,
+        usedHints: [],
+        wrongAnswers: [],
+        questions: [],
+      },
+      topics: [{ id: 1, name: 'HTML' }],
+      isLoading: false,
+      ui: {
+        theme: 'light',
+        activeRoute: ROUTES.Library,
+        isNavOpen: false,
+        onboardingSeen: false,
+        selectedLibraryDifficulty: 'easy',
+      },
+    });
+
+    mocks.getResumeCandidate.mockResolvedValue({
+      game: resumeGameMock,
+      source: 'local',
+    });
+
+    const view = createLibraryView();
+    document.body.append(view);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Continue?' })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue?' }));
+
+    await waitFor(() => {
+      expect(mocks.restoreGameState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topicId: 1,
+          difficulty: 'easy',
+        })
+      );
+
+      expect(mocks.showModal).not.toHaveBeenCalled();
+      expect(mocks.startNewGame).not.toHaveBeenCalled();
+      expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
+    });
+  });
+
+  test('shows restart confirmation when starting same unfinished topic', async () => {
     mocks.getTopics.mockResolvedValue([{ id: 1, name: 'HTML' }]);
 
     mocks.getState.mockReturnValue({
@@ -286,18 +341,16 @@ describe('createLibraryView', () => {
     await waitFor(() => {
       expect(mocks.showModal).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: 'Continue previous topic?',
+          title: 'Start topic from the beginning?',
           messageHtml: expect.stringContaining('HTML'),
         })
       );
 
-      expect(mocks.restoreGameState).toHaveBeenCalledWith(
-        expect.objectContaining({
-          topicId: 1,
-          difficulty: 'easy',
-        })
-      );
-      expect(mocks.startNewGame).not.toHaveBeenCalled();
+      expect(mocks.startNewGame).toHaveBeenCalledWith({
+        topicId: 1,
+        difficulty: 'easy',
+      });
+      expect(mocks.restoreGameState).not.toHaveBeenCalled();
       expect(mocks.navigate).toHaveBeenCalledWith(ROUTES.Practice, true);
     });
   });

--- a/src/pages/library/library.ts
+++ b/src/pages/library/library.ts
@@ -20,18 +20,28 @@ import { fetchCompletedTopicIds } from '../../services/api/fetch-completed-topic
 import { getState } from '../../app/state/store';
 import { getResumeCandidate } from '../../services/resume-active-game';
 import {
-  confirmContinueSameTopic,
   confirmReplaceActiveTopic,
+  confirmRestartActiveTopic,
 } from './library-resume-modals.ts';
 
 type GameState = AppState['game'];
 
+type CreateTopicCardParams = {
+  topic: Topic;
+  isCompleted: boolean;
+  isActiveTopic: boolean;
+  onStart: (startBtn: HTMLButtonElement) => void;
+  onContinue: () => void;
+};
+
 function isSameActiveTopic(
-  activeGame: GameState,
+  activeTopic: GameState,
   topicId: number,
   difficulty: Difficulty
 ): boolean {
-  return activeGame.topicId === topicId && activeGame.difficulty === difficulty;
+  return (
+    activeTopic.topicId === topicId && activeTopic.difficulty === difficulty
+  );
 }
 
 function getTopicTitleById(topicId: number): string {
@@ -42,28 +52,40 @@ function getTopicTitleById(topicId: number): string {
   );
 }
 
-function createTopicCard(
-  topic: Topic,
-  isCompleted: boolean,
-  onStart: (startBtn: HTMLButtonElement) => void
-): HTMLElement {
+function createTopicCard({
+  topic,
+  isCompleted,
+  isActiveTopic,
+  onStart,
+  onContinue,
+}: CreateTopicCardParams): HTMLElement {
   const card = createEl('div', {
     className: `library-card${isCompleted ? ' is-completed' : ''}`,
+  });
+
+  const header = createEl('div', {
+    className: 'library-card-header',
   });
 
   const name = createEl('div', {
     text: topic.name ?? `Topic #${topic.id}`,
     className: 'library-card-title',
   });
+  header.append(name);
+
+  if (isActiveTopic) {
+    const activeBadge = createEl('span', {
+      text: 'Unfinished',
+      className: 'library-topic-badge',
+    });
+
+    header.append(activeBadge);
+  }
 
   const actions = createEl('div', { className: 'library-card-actions' });
-
-  const startBtn = createButton(
-    'Start',
-    () => onStart(startBtn as HTMLButtonElement),
-    'btn',
-    isCompleted
-  );
+  const actionsRight = createEl('div', {
+    className: 'library-card-actions-right',
+  });
 
   if (isCompleted) {
     const topicIcon = createEl('img', {
@@ -76,8 +98,25 @@ function createTopicCard(
     actions.append(topicIcon);
   }
 
-  actions.append(startBtn);
-  card.append(name, actions);
+  if (isActiveTopic) {
+    const continueBtn = createButton(
+      'Continue?',
+      onContinue,
+      'btn btn-secondary'
+    );
+    actionsRight.append(continueBtn);
+  }
+
+  const startBtn = createButton(
+    'Start',
+    () => onStart(startBtn as HTMLButtonElement),
+    'btn',
+    isCompleted
+  );
+  actionsRight.append(startBtn);
+
+  actions.append(actionsRight);
+  card.append(header, actions);
 
   return card;
 }
@@ -139,9 +178,20 @@ export const createLibraryView = (): HTMLElement => {
     });
   };
 
+  const handleContinueClick = (activeTopic: GameState | null): void => {
+    if (!activeTopic) return;
+
+    status.textContent = '';
+    status.classList.remove('is-error');
+
+    restoreGameState(activeTopic);
+    navigate(ROUTES.Practice, true);
+  };
+
   const handleStartClick = async (
     topicId: number,
-    startBtn: HTMLButtonElement
+    startBtn: HTMLButtonElement,
+    activeTopic: GameState | null
   ): Promise<void> => {
     status.textContent = '';
     status.classList.remove('is-error');
@@ -150,30 +200,20 @@ export const createLibraryView = (): HTMLElement => {
     let shouldEnableButton = true;
 
     try {
-      const activeCandidate = await getResumeCandidate();
-      const activeGame = activeCandidate?.game;
-
-      if (activeGame && isSameActiveTopic(activeGame, topicId, difficulty)) {
-        const activeTopicTitle = getTopicTitleById(activeGame.topicId);
-        const shouldContinue = await confirmContinueSameTopic(
-          activeGame.difficulty,
+      if (activeTopic && isSameActiveTopic(activeTopic, topicId, difficulty)) {
+        const activeTopicTitle = getTopicTitleById(activeTopic.topicId);
+        const shouldRestart = await confirmRestartActiveTopic(
+          activeTopic.difficulty,
           activeTopicTitle
         );
 
-        if (!shouldContinue) {
+        if (!shouldRestart) {
           return;
         }
-
-        restoreGameState(activeGame);
-        shouldEnableButton = false;
-        navigate(ROUTES.Practice, true);
-        return;
-      }
-
-      if (activeGame) {
-        const activeTopicTitle = getTopicTitleById(activeGame.topicId);
+      } else if (activeTopic) {
+        const activeTopicTitle = getTopicTitleById(activeTopic.topicId);
         const shouldReplace = await confirmReplaceActiveTopic(
-          activeGame.difficulty,
+          activeTopic.difficulty,
           activeTopicTitle
         );
 
@@ -208,9 +248,10 @@ export const createLibraryView = (): HTMLElement => {
     list.replaceChildren(createLoadingView('Loading topics...'));
 
     try {
-      const [topics, completedTopicIds] = await Promise.all([
+      const [topics, completedTopicIds, activeCandidate] = await Promise.all([
         getTopics(),
         fetchCompletedTopicIds(difficulty),
+        getResumeCandidate(),
       ]);
 
       list.replaceChildren();
@@ -226,14 +267,25 @@ export const createLibraryView = (): HTMLElement => {
       }
 
       const completedIds = new Set(completedTopicIds);
+      const activeTopic = activeCandidate?.game ?? null;
 
       topics.forEach((topic) => {
+        const isCompleted = completedIds.has(topic.id);
+        const isActiveTopic =
+          Boolean(activeTopic) &&
+          activeTopic?.difficulty === difficulty &&
+          activeTopic.topicId === topic.id &&
+          !isCompleted;
+
         list.append(
-          createTopicCard(
+          createTopicCard({
             topic,
-            completedIds.has(topic.id),
-            (startBtn) => void handleStartClick(topic.id, startBtn)
-          )
+            isCompleted,
+            isActiveTopic,
+            onContinue: () => void handleContinueClick(activeTopic),
+            onStart: (startBtn) =>
+              void handleStartClick(topic.id, startBtn, activeTopic),
+          })
         );
       });
 


### PR DESCRIPTION
## Описание

Обновлен flow незавершенного топика в `Library`.

Теперь действия разделены:
- `Continue?` — продолжает сохраненный прогресс (без вызова модального окна)
- `Start` — запускает топик заново (с вызовом модального окна, если есть незавершенный прогресс по одному из топиков)

## Что сделано

- добавлена отдельная кнопка `Continue?` для незавершенного топика (сразу продолжает незавершенный топик, не вызывает модального окна)
- обновлена логика модалок для restart / replace сценариев
- обновлены разметка и стили карточки топика
- обновлены тесты библиотеки под новый flow

## Результат

Поведение в `Library` стало понятнее: пользователь явно выбирает, продолжить текущий прогресс или начать топик заново.

## Continue для незавершенного топика
<img width="1470" height="956" alt="Screenshot 2026-04-13 at 15 24 47" src="https://github.com/user-attachments/assets/c9acce40-684c-4475-842d-988ec211fb96" />


## Restart modal при нажатии на `Start`
<img width="1470" height="956" alt="Screenshot 2026-04-13 at 15 24 54" src="https://github.com/user-attachments/assets/a9b5d896-c881-43d7-8221-a47548f8182d" />
