### PR TITLE
Test/resume flow coverage

### DIFF
--- a/src/services/api/active-games.test.ts
+++ b/src/services/api/active-games.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PersistedActiveSession } from '../../types';
+
+const mocks = vi.hoisted(() => ({
+  maybeSingle: vi.fn(),
+  selectEq: vi.fn(),
+  select: vi.fn(),
+  upsert: vi.fn(),
+  deleteEq: vi.fn(),
+  delete: vi.fn(),
+  from: vi.fn(),
+  withApiErrorHandling: vi.fn(),
+}));
+
+vi.mock('../supabase-client.ts', () => ({
+  supabase: {
+    from: mocks.from,
+  },
+}));
+
+vi.mock('../../shared/helpers/request-error.ts', () => ({
+  withApiErrorHandling: mocks.withApiErrorHandling,
+}));
+
+import {
+  deleteActiveGame,
+  getActiveSessionByUser,
+  upsertActiveSession,
+} from './active-games';
+
+describe('active-games', () => {
+  const session = {
+    gameId: 1,
+    game: {
+      topicId: 2,
+      difficulty: 'easy',
+      round: 1,
+    },
+  } as unknown as PersistedActiveSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.withApiErrorHandling.mockImplementation(
+      async (callback: () => Promise<unknown>) => callback()
+    );
+
+    mocks.select.mockReturnValue({
+      eq: mocks.selectEq,
+    });
+
+    mocks.selectEq.mockReturnValue({
+      maybeSingle: mocks.maybeSingle,
+    });
+
+    mocks.delete.mockReturnValue({
+      eq: mocks.deleteEq,
+    });
+
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'active_games') {
+        return {
+          select: mocks.select,
+          upsert: mocks.upsert,
+          delete: mocks.delete,
+        };
+      }
+
+      return {};
+    });
+  });
+
+  it('returns active session from database', async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        game_id: 1,
+        game_state: session.game,
+      },
+      error: null,
+    });
+
+    const result = await getActiveSessionByUser('user-1');
+
+    expect(result).toEqual(session);
+  });
+
+  it('returns null when there is no game_state', async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: null,
+      error: null,
+    });
+
+    const result = await getActiveSessionByUser('user-1');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws when getActiveSessionByUser gets supabase error', async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: null,
+      error: new Error('boom'),
+    });
+
+    await expect(getActiveSessionByUser('user-1')).rejects.toThrow('boom');
+  });
+
+  it('upserts active session', async () => {
+    mocks.upsert.mockResolvedValue({
+      error: null,
+    });
+
+    await upsertActiveSession('user-1', session);
+
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        game_id: 1,
+        game_state: session.game,
+        updated_at: expect.any(String),
+      }),
+      { onConflict: 'user_id' }
+    );
+  });
+
+  it('deletes active game', async () => {
+    mocks.deleteEq.mockResolvedValue({ error: null });
+
+    await deleteActiveGame('user-1');
+
+    expect(mocks.delete).toHaveBeenCalled();
+    expect(mocks.deleteEq).toHaveBeenCalledWith('user_id', 'user-1');
+  });
+});

--- a/src/services/current-game.test.ts
+++ b/src/services/current-game.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getLatestGameByUser: vi.fn(),
+}));
+
+vi.mock('./api/get-games', () => ({
+  getLatestGameByUser: mocks.getLatestGameByUser,
+}));
+
+import { resolveCurrentGame } from './current-game';
+
+describe('current-game', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns no-game when no record found', async () => {
+    mocks.getLatestGameByUser.mockResolvedValue(null);
+
+    await expect(resolveCurrentGame('user-1')).resolves.toEqual({
+      status: 'no-game',
+    });
+  });
+
+  it('returns success for unfinished game', async () => {
+    mocks.getLatestGameByUser.mockResolvedValue({
+      id: 10,
+      achievement: null,
+    });
+
+    await expect(resolveCurrentGame('user-1')).resolves.toEqual({
+      status: 'success',
+      gameId: 10,
+    });
+  });
+
+  it('returns error when request fails', async () => {
+    mocks.getLatestGameByUser.mockRejectedValue(new Error('boom'));
+
+    await expect(resolveCurrentGame('user-1')).resolves.toEqual({
+      status: 'error',
+    });
+  });
+});

--- a/src/services/login-game-choice-flow.test.ts
+++ b/src/services/login-game-choice-flow.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  resolveCurrentGame: vi.fn(),
+  showModal: vi.fn(),
+}));
+
+vi.mock('./current-game', () => ({
+  resolveCurrentGame: mocks.resolveCurrentGame,
+}));
+
+vi.mock('../components/ui/modal/modal', () => ({
+  showModal: mocks.showModal,
+}));
+
+import { runLoginGameChoiceFlow } from './login-game-choice-flow';
+
+describe('login-game-choice-flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns no-game when there is no current game', async () => {
+    mocks.resolveCurrentGame.mockResolvedValue({ status: 'no-game' });
+
+    await expect(runLoginGameChoiceFlow('user-1')).resolves.toEqual({
+      status: 'no-game',
+    });
+  });
+
+  it('returns continued when user chooses continue', async () => {
+    mocks.resolveCurrentGame.mockResolvedValue({
+      status: 'success',
+      gameId: 1,
+    });
+    mocks.showModal.mockResolvedValue({ confirmed: true });
+
+    await expect(runLoginGameChoiceFlow('user-1')).resolves.toEqual({
+      status: 'continued',
+      gameId: 1,
+    });
+  });
+
+  it('returns start-new when user chooses new game', async () => {
+    mocks.resolveCurrentGame.mockResolvedValue({
+      status: 'success',
+      gameId: 1,
+    });
+    mocks.showModal.mockResolvedValue({ confirmed: false });
+
+    await expect(runLoginGameChoiceFlow('user-1')).resolves.toEqual({
+      status: 'start-new',
+    });
+  });
+});

--- a/src/services/storage-service.test.ts
+++ b/src/services/storage-service.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { PersistedActiveSession } from '../types';
+import {
+  clearActiveGame,
+  clearActiveSession,
+  getActiveSession,
+  saveActiveSession,
+} from './storage-service';
+
+describe('storage-service', () => {
+  const session = {
+    gameId: 1,
+    game: {
+      topicId: 1,
+      difficulty: 'easy',
+      round: 1,
+    },
+  } as PersistedActiveSession;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves active session', () => {
+    saveActiveSession(session);
+
+    expect(localStorage.getItem('activeGame')).toBe(JSON.stringify(session));
+  });
+
+  it('gets active session', () => {
+    localStorage.setItem('activeGame', JSON.stringify(session));
+
+    expect(getActiveSession()).toEqual(session);
+  });
+
+  it('returns null when there is no active session', () => {
+    expect(getActiveSession()).toBeNull();
+  });
+
+  it('returns legacy game as session with null gameId', () => {
+    const legacyGame = {
+      topicId: 2,
+      difficulty: 'medium',
+      round: 3,
+    };
+
+    localStorage.setItem('activeGame', JSON.stringify(legacyGame));
+
+    expect(getActiveSession()).toEqual({
+      gameId: null,
+      game: legacyGame,
+    });
+  });
+
+  it('clears active session', () => {
+    localStorage.setItem('activeGame', JSON.stringify(session));
+
+    clearActiveSession();
+
+    expect(localStorage.getItem('activeGame')).toBeNull();
+  });
+
+  it('clearActiveGame also clears storage', () => {
+    localStorage.setItem('activeGame', JSON.stringify(session));
+
+    clearActiveGame();
+
+    expect(localStorage.getItem('activeGame')).toBeNull();
+  });
+});

--- a/src/services/sync-active-game.test.ts
+++ b/src/services/sync-active-game.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  getState: vi.fn(),
+  upsertActiveSession: vi.fn(),
+  deleteActiveGame: vi.fn(),
+}));
+
+vi.mock('./auth-service', () => ({
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+vi.mock('../app/state/store', () => ({
+  getState: mocks.getState,
+}));
+
+vi.mock('./api/active-games', () => ({
+  upsertActiveSession: mocks.upsertActiveSession,
+  deleteActiveGame: mocks.deleteActiveGame,
+}));
+
+import {
+  removeActiveGameFromServer,
+  syncActiveGameToServer,
+} from './sync-active-game';
+
+describe('sync-active-game', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getState.mockReturnValue({
+      gameId: 1,
+      game: { topicId: 1, difficulty: 'easy', round: 1 },
+    });
+  });
+
+  it('does nothing without user', async () => {
+    mocks.getCurrentUser.mockReturnValue(null);
+
+    await syncActiveGameToServer();
+
+    expect(mocks.upsertActiveSession).not.toHaveBeenCalled();
+  });
+
+  it('syncs active game for current user', async () => {
+    mocks.getCurrentUser.mockReturnValue({ id: 'user-1' });
+
+    await syncActiveGameToServer();
+
+    expect(mocks.upsertActiveSession).toHaveBeenCalled();
+  });
+
+  it('removes active game for current user', async () => {
+    mocks.getCurrentUser.mockReturnValue({ id: 'user-1' });
+
+    await removeActiveGameFromServer();
+
+    expect(mocks.deleteActiveGame).toHaveBeenCalledWith('user-1');
+  });
+});

--- a/src/services/topic-resume-candidate.test.ts
+++ b/src/services/topic-resume-candidate.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getActiveSession: vi.fn(),
+  getActiveSessionByUser: vi.fn(),
+  fetchCompletedTopicIds: vi.fn(),
+}));
+
+vi.mock('./storage-service', () => ({
+  getActiveSession: mocks.getActiveSession,
+}));
+
+vi.mock('./api/active-games', () => ({
+  getActiveSessionByUser: mocks.getActiveSessionByUser,
+}));
+
+vi.mock('./api/fetch-completed-topic-ids', () => ({
+  fetchCompletedTopicIds: mocks.fetchCompletedTopicIds,
+}));
+
+import {
+  getTopicResumeCandidate,
+  hasRequiredResumeData,
+} from './topic-resume-candidate';
+import type { PersistedActiveSession } from '../types';
+
+describe('topic-resume-candidate', () => {
+  const session = {
+    gameId: 1,
+    game: {
+      topicId: 1,
+      difficulty: 'easy',
+      round: 1,
+      usedHints: {
+        '50/50': 0,
+        'call a friend': 0,
+        "i don't know": 0,
+      },
+      questions: [{ question: 'q' }],
+    },
+  } as PersistedActiveSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchCompletedTopicIds.mockResolvedValue([]);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('validates correct resume data', () => {
+    expect(hasRequiredResumeData(session.game)).toBe(true);
+  });
+
+  it('returns local session first', async () => {
+    mocks.getActiveSession.mockReturnValue(session);
+
+    const result = await getTopicResumeCandidate('user-1');
+
+    expect(result).toEqual(session);
+  });
+
+  it('returns server session when local is missing', async () => {
+    mocks.getActiveSession.mockReturnValue(null);
+    mocks.getActiveSessionByUser.mockResolvedValue(session);
+
+    const result = await getTopicResumeCandidate('user-1');
+
+    expect(result).toEqual(session);
+  });
+
+  it('returns null when server throws', async () => {
+    mocks.getActiveSession.mockReturnValue(null);
+    mocks.getActiveSessionByUser.mockRejectedValue(new Error('boom'));
+
+    const result = await getTopicResumeCandidate('user-1');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/shared/helpers/request-error.test.ts
+++ b/src/shared/helpers/request-error.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getApiErrorMessage, withApiErrorHandling } from './request-error';
+
+describe('request-error', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns fallback when online', () => {
+    vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(true);
+
+    expect(getApiErrorMessage('Failed to load data')).toBe(
+      'Failed to load data'
+    );
+  });
+
+  it('returns no internet message when offline', () => {
+    vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
+
+    expect(getApiErrorMessage('Failed to load data')).toBe(
+      'No internet connection.'
+    );
+  });
+
+  it('returns request result when request succeeds', async () => {
+    const request = vi.fn().mockResolvedValue('ok');
+
+    await expect(withApiErrorHandling(request, 'Failed')).resolves.toBe('ok');
+  });
+
+  it('throws fallback error when request fails', async () => {
+    vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(true);
+
+    const request = vi.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(withApiErrorHandling(request, 'Failed')).rejects.toThrow(
+      'Failed'
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Что сделано
Добавлено unit test покрытие для сервисов resume flow и active session. В PR включены тесты для ключевых helper/service-модулей.