### PR TITLE
fix: save score of completed topics

### DIFF
--- a/src/app/state/actions.ts
+++ b/src/app/state/actions.ts
@@ -329,6 +329,7 @@ export async function startNewGame(params: {
       topicId: params.topicId,
       difficulty: params.difficulty,
       round: 1,
+      score: prev.game.score,
     },
   });
 

--- a/src/app/state/actions.ts
+++ b/src/app/state/actions.ts
@@ -319,6 +319,7 @@ export function removeUserData() {
 export async function startNewGame(params: {
   topicId: number;
   difficulty: Difficulty;
+  isRestart?: boolean;
 }) {
   const prev = getState();
 
@@ -329,7 +330,7 @@ export async function startNewGame(params: {
       topicId: params.topicId,
       difficulty: params.difficulty,
       round: 1,
-      score: prev.game.score,
+      score: params.isRestart ? initialGameState.score : prev.game.score,
     },
   });
 

--- a/src/components/ui/final-screen/final-screen.ts
+++ b/src/components/ui/final-screen/final-screen.ts
@@ -50,7 +50,7 @@ export async function createFinalScreen() {
     try {
       await deleteCompletedTopics(difficulty);
       await finishCurrentGame();
-      await startNewGame({ topicId: 1, difficulty });
+      await startNewGame({ topicId: 1, difficulty, isRestart: true });
       navigate(ROUTES.Practice, true);
     } catch (error) {
       console.error('Failed to restart progress:', error);


### PR DESCRIPTION
**Changes**

Preserve score when starting a new topic. Previously, the score was reset to 0 when starting a new topic after completing another one (e.g., navigating from results back to library and selecting a new topic).

This change ensures that the existing score is preserved by carrying over the previous value:

score: prev.game.score,

Now the score remains consistent across topic transitions.