### PR TITLE
fix: make practice card full width on mobile

### DIFF
--- a/src/components/ui/practice-card/practice-card.scss
+++ b/src/components/ui/practice-card/practice-card.scss
@@ -187,3 +187,10 @@
     background-position: 200% 50%;
   }
 }
+
+@media (max-width: 480px) {
+  .card {
+    width: 100%;
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## Что сделано
Исправлено отображение карточки практики на мобильных экранах. Для экранов до 480px ширина .card теперь устанавливается в 100%, чтобы карточка не сжималась слишком сильно на 320px.